### PR TITLE
Add CI checks for starter kit docs and templates

### DIFF
--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -1,0 +1,121 @@
+name: Docs and Templates
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - ".github/ISSUE_TEMPLATE/**/*.yml"
+      - ".github/ISSUE_TEMPLATE/**/*.yaml"
+      - ".github/workflows/**/*.yml"
+      - ".github/workflows/**/*.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "**/*.md"
+      - ".github/ISSUE_TEMPLATE/**/*.yml"
+      - ".github/ISSUE_TEMPLATE/**/*.yaml"
+      - ".github/workflows/**/*.yml"
+      - ".github/workflows/**/*.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  docs-and-templates:
+    name: Validate docs and templates
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate YAML syntax
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t yaml_files < <(find .github -type f \( -name "*.yml" -o -name "*.yaml" \) | sort)
+
+          if [ "${#yaml_files[@]}" -eq 0 ]; then
+            echo "No YAML files found."
+            exit 0
+          fi
+
+          ruby -e '
+            require "yaml"
+            ARGV.each do |path|
+              YAML.load_file(path)
+              puts "YAML OK: #{path}"
+            rescue Psych::SyntaxError => e
+              warn "YAML ERROR: #{path}: #{e.message}"
+              exit 1
+            end
+          ' "${yaml_files[@]}"
+
+      - name: Validate Markdown hygiene
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t markdown_files < <(find . -type f -name "*.md" -not -path "./.git/*" | sort)
+
+          if [ "${#markdown_files[@]}" -eq 0 ]; then
+            echo "No Markdown files found."
+            exit 0
+          fi
+
+          python3 - <<'PY' "${markdown_files[@]}"
+          import pathlib
+          import sys
+
+          failed = False
+
+          for raw_path in sys.argv[1:]:
+              path = pathlib.Path(raw_path)
+              text = path.read_text(encoding="utf-8")
+              lines = text.splitlines()
+
+              if text and not text.endswith("\n"):
+                  print(f"Markdown ERROR: {path}: file must end with a newline")
+                  failed = True
+
+              for index, line in enumerate(lines, start=1):
+                  if line.rstrip(" \t") != line:
+                      print(f"Markdown ERROR: {path}:{index}: trailing whitespace")
+                      failed = True
+                  if "\t" in line:
+                      print(f"Markdown ERROR: {path}:{index}: tab character")
+                      failed = True
+
+              print(f"Markdown OK: {path}")
+
+          if failed:
+              sys.exit(1)
+          PY
+
+      - name: Validate starter kit structure
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "README.md"
+            "README.ko.md"
+            "AGENTS.md"
+            ".github/PULL_REQUEST_TEMPLATE.md"
+            ".github/ISSUE_TEMPLATE/jules_task.yml"
+            ".github/ISSUE_TEMPLATE/workflow_experiment.yml"
+            "docs/workflows/workflow-levels.md"
+            "docs/experiments/no-human-only-jules-workflow.md"
+            "docs/experiments/jules-alpha-evolve.md"
+            "prompts/issue-to-jules-task.md"
+            "prompts/daily-maintainer-report.md"
+          )
+
+          for path in "${required_paths[@]}"; do
+            if [ ! -f "$path" ]; then
+              echo "Missing required starter kit file: $path"
+              exit 1
+            fi
+            echo "Found: $path"
+          done

--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -80,11 +80,19 @@ jobs:
                   failed = True
 
               for index, line in enumerate(lines, start=1):
-                  if line.rstrip(" \t") != line:
-                      print(f"Markdown ERROR: {path}:{index}: trailing whitespace")
-                      failed = True
                   if "\t" in line:
                       print(f"Markdown ERROR: {path}:{index}: tab character")
+                      failed = True
+
+                  stripped = line.rstrip(" ")
+                  trailing_spaces = len(line) - len(stripped)
+
+                  # Allow exactly two trailing spaces for Markdown hard line breaks.
+                  if trailing_spaces not in (0, 2):
+                      print(
+                          f"Markdown ERROR: {path}:{index}: "
+                          f"unexpected trailing spaces ({trailing_spaces})"
+                      )
                       failed = True
 
               print(f"Markdown OK: {path}")

--- a/docs/workflows/workflow-levels.md
+++ b/docs/workflows/workflow-levels.md
@@ -81,6 +81,18 @@ Evaluator defines score
 
 This works best for measurable optimization targets, not vague product direction.
 
+## CI Gate for Starter Kit Changes
+
+This repository includes a lightweight GitHub Actions workflow for documentation and template changes.
+
+The workflow checks:
+
+- YAML syntax under `.github/`
+- basic Markdown hygiene, including trailing whitespace, tabs, and final newlines
+- required starter kit files such as `README.md`, `AGENTS.md`, issue templates, workflow docs, experiment docs, and prompt examples
+
+The check is intentionally small so other projects can copy it as a starter kit example. It is not meant to replace project-specific test suites.
+
 ## Rule of Thumb
 
 The more autonomous the workflow becomes, the stronger the safety gates must be.


### PR DESCRIPTION
## Summary

Closes #5

Adds a lightweight GitHub Actions workflow for validating starter kit documentation and GitHub templates.

## Workflow Level

- [x] Level 1: Human-led Jules workflow
- [ ] Level 2: Semi-autonomous Jules workflow
- [ ] Level 3: Human issue only
- [ ] Level 4: Daily agentic maintainer loop
- [ ] Experiment: no-human sandbox or evaluator-driven evolution

## Changes

- Add `.github/workflows/docs-and-templates.yml`.
- Validate YAML syntax for files under `.github/`.
- Validate basic Markdown hygiene:
  - final newline
  - no trailing whitespace
  - no tab characters
- Check that required starter kit files exist.
- Document the CI gate in `docs/workflows/workflow-levels.md`.

## Validation

- [x] Workflow file added.
- [x] YAML validation uses Ruby's built-in YAML parser on GitHub-hosted Ubuntu runners.
- [x] Markdown hygiene check uses Python from the default runner image.
- [x] No heavy dependencies or project-specific build system added.

Validation notes:

```text
This is a documentation/template CI workflow. It will run on pull requests and pushes to main when Markdown, issue templates, or workflow files change.
```

## Scope Control

- [x] This PR only changes files needed for Issue #5.
- [x] No unrelated refactors are included.
- [x] Repository positioning and README messaging are unchanged.

Assumptions:

```text
The CI should be lightweight and copyable, so it avoids external package installation and uses tools already available on GitHub-hosted Ubuntu runners.
```

## Maintainer Review Checklist

- [ ] The PR solves the linked issue.
- [ ] The diff is small enough to review.
- [ ] CI or manual validation is sufficient.
- [ ] The change keeps Jules clearly represented as an AI coding agent, not a human contributor.
- [ ] The project history remains understandable.
