### PR TITLE
[Jules Task] Add Case Study A: digital-logic-circuit

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -166,7 +166,7 @@ Merge 전에 다음을 확인합니다.
 
 ## Case Studies
 
-### Case Study A: Digital Logic Circuit
+### [Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)
 
 Repository: <https://github.com/hkimw-underground/digital-logic-circuit>
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Before merging, check:
 
 ## Case Studies
 
-### Case Study A: Digital Logic Circuit
+### [Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)
 
 Repository: <https://github.com/hkimw-underground/digital-logic-circuit>
 

--- a/docs/case-studies/digital-logic-circuit.md
+++ b/docs/case-studies/digital-logic-circuit.md
@@ -1,0 +1,62 @@
+# Case Study A: Digital Logic Circuit
+
+## Repository Overview
+
+Repository: `hkimw-underground/digital-logic-circuit`
+
+The `digital-logic-circuit` repository is a real-world hardware and software capstone project. It serves as an excellent case study for integrating an AI coding agent (Jules) into a standard GitHub development workflow.
+
+## Why This is a Good Case Study
+
+Unlike simple, isolated software experiments, a capstone project involves external constraints, complex architectures, and concrete milestones. Demonstrating the workflow here proves that the GitHub-native Issue → PR → Review → CI process works effectively for substantial, structured projects, preventing AI-generated changes from bypassing necessary engineering standards.
+
+## Project Planning and GitHub Issues
+
+Historically, project planning for this capstone might have relied on external trackers or ad-hoc communication. To enable the AI-assisted workflow, planning has been explicitly moved into GitHub Issues.
+
+1. **Issue Creation**: The human maintainer translates high-level project goals into small, scoped GitHub Issues.
+2. **Context**: Each issue acts as the absolute source of truth, describing the problem, scope, constraints, and validation steps.
+
+## Workflow Execution: Issue → Jules → PR → Review → CI
+
+This case study implements a clear, linear workflow:
+
+1. **Issue**: The human maintainer opens a scoped GitHub Issue.
+2. **Jules**: Jules, acting as an AI coding agent, reads the issue and implements the necessary changes.
+3. **PR**: Jules creates a small, focused Pull Request linking back to the issue.
+4. **Review**: The human maintainer reviews the PR against the issue requirements and architecture guidelines.
+5. **CI**: Automated Continuous Integration (CI) checks run against the proposed changes to validate correctness.
+
+## Separation of Responsibilities
+
+A key tenet of this workflow is the strict boundary between human and AI responsibilities. Jules is an AI coding agent, not a human contributor or a substitute for engineering judgment.
+
+### Human Maintainer Responsibilities
+- Define project architecture and hardware constraints.
+- Scope and create GitHub Issues.
+- Review Pull Requests submitted by Jules.
+- Make the final merge decisions.
+- Ensure the project direction aligns with external capstone requirements.
+
+### Jules Responsibilities
+- Read and understand the assigned GitHub Issue.
+- Implement the requested code or documentation changes.
+- Ensure changes are small, focused, and strictly scoped to the issue.
+- Open a Pull Request for human review.
+- Explain assumptions in the PR description if an issue is ambiguous.
+
+## CI and Validation Expectations
+
+Continuous Integration is critical. For this repository, CI should cover:
+- Syntax and compilation checks for any software components.
+- Automated tests or simulations for logic circuits.
+- Formatting and linting rules to maintain codebase consistency.
+- Any repository-specific validation steps defined by the maintainer.
+
+## Lessons for Other Maintainers
+
+This case study demonstrates that:
+- AI agents work best when bound by traditional engineering workflows (Issues and PRs).
+- Keeping PRs small and strictly scoped to a single issue makes human review manageable.
+- Human ownership of architecture and final review is non-negotiable for real projects.
+- Explicit CI gates protect the main branch from unverified AI implementations.

--- a/docs/case-studies/digital-logic-circuit.md
+++ b/docs/case-studies/digital-logic-circuit.md
@@ -4,34 +4,35 @@
 
 Repository: `hkimw-underground/digital-logic-circuit`
 
-The `digital-logic-circuit` repository is a real-world hardware and software capstone project. It serves as an excellent case study for integrating an AI coding agent (Jules) into a standard GitHub development workflow.
+The `digital-logic-circuit` repository is a real-world hardware and software capstone project. It serves as a case study for integrating an AI coding agent, Jules, into a standard GitHub development workflow.
 
 ## Why This is a Good Case Study
 
-Unlike simple, isolated software experiments, a capstone project involves external constraints, complex architectures, and concrete milestones. Demonstrating the workflow here proves that the GitHub-native Issue → PR → Review → CI process works effectively for substantial, structured projects, preventing AI-generated changes from bypassing necessary engineering standards.
+Unlike simple, isolated software experiments, a capstone project involves external constraints, complex architectures, and concrete milestones. Demonstrating the workflow here shows how the GitHub-native Issue → PR → Review → CI process can work for a structured project while keeping engineering review visible.
 
 ## Project Planning and GitHub Issues
 
 Historically, project planning for this capstone might have relied on external trackers or ad-hoc communication. To enable the AI-assisted workflow, planning has been explicitly moved into GitHub Issues.
 
 1. **Issue Creation**: The human maintainer translates high-level project goals into small, scoped GitHub Issues.
-2. **Context**: Each issue acts as the absolute source of truth, describing the problem, scope, constraints, and validation steps.
+2. **Context**: Each issue acts as the source of truth, describing the problem, scope, constraints, and validation steps.
 
 ## Workflow Execution: Issue → Jules → PR → Review → CI
 
-This case study implements a clear, linear workflow:
+This case study describes a clear, linear workflow:
 
 1. **Issue**: The human maintainer opens a scoped GitHub Issue.
 2. **Jules**: Jules, acting as an AI coding agent, reads the issue and implements the necessary changes.
 3. **PR**: Jules creates a small, focused Pull Request linking back to the issue.
 4. **Review**: The human maintainer reviews the PR against the issue requirements and architecture guidelines.
-5. **CI**: Automated Continuous Integration (CI) checks run against the proposed changes to validate correctness.
+5. **CI**: Automated Continuous Integration checks run against the proposed changes to validate correctness.
 
 ## Separation of Responsibilities
 
 A key tenet of this workflow is the strict boundary between human and AI responsibilities. Jules is an AI coding agent, not a human contributor or a substitute for engineering judgment.
 
 ### Human Maintainer Responsibilities
+
 - Define project architecture and hardware constraints.
 - Scope and create GitHub Issues.
 - Review Pull Requests submitted by Jules.
@@ -39,6 +40,7 @@ A key tenet of this workflow is the strict boundary between human and AI respons
 - Ensure the project direction aligns with external capstone requirements.
 
 ### Jules Responsibilities
+
 - Read and understand the assigned GitHub Issue.
 - Implement the requested code or documentation changes.
 - Ensure changes are small, focused, and strictly scoped to the issue.
@@ -47,7 +49,8 @@ A key tenet of this workflow is the strict boundary between human and AI respons
 
 ## CI and Validation Expectations
 
-Continuous Integration is critical. For this repository, CI should cover:
+Continuous Integration is critical. For the `digital-logic-circuit` repository, CI should cover:
+
 - Syntax and compilation checks for any software components.
 - Automated tests or simulations for logic circuits.
 - Formatting and linting rules to maintain codebase consistency.
@@ -56,7 +59,8 @@ Continuous Integration is critical. For this repository, CI should cover:
 ## Lessons for Other Maintainers
 
 This case study demonstrates that:
-- AI agents work best when bound by traditional engineering workflows (Issues and PRs).
+
+- AI agents work best when bound by traditional engineering workflows, especially Issues and PRs.
 - Keeping PRs small and strictly scoped to a single issue makes human review manageable.
 - Human ownership of architecture and final review is non-negotiable for real projects.
-- Explicit CI gates protect the main branch from unverified AI implementations.
+- Explicit CI gates help keep the main branch reviewable and maintainable.


### PR DESCRIPTION
Closes #7.

This PR adds `docs/case-studies/digital-logic-circuit.md` to document the hardware/software capstone project as Case Study A, proving the workflow is not just theoretical. 

It covers:
- Overview of the repository
- Why it is a good Jules workflow case study
- The move toward GitHub Issues for planning
- The Issue → Jules → PR → Review → CI workflow execution
- Separation of responsibilities between human maintainers and Jules
- CI and validation expectations
- Lessons for other maintainers

The `README.md` and `README.ko.md` have been updated to link to this new case study file.

### Validation
- [x] Confirmed the new Markdown file passes docs CI by running the hygiene script locally.
- [x] Confirmed links are relative.
- [x] Confirmed the tone is practical and maintainer-oriented.

---
*PR created automatically by Jules for task [17873778786546632466](https://jules.google.com/task/17873778786546632466) started by @hkimw*