### PR TITLE
Add SECURITY.md security policy

### DIFF
--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -110,6 +110,7 @@ jobs:
             "README.md"
             "README.ko.md"
             "CONTRIBUTING.md"
+            "SECURITY.md"
             "AGENTS.md"
             ".github/PULL_REQUEST_TEMPLATE.md"
             ".github/ISSUE_TEMPLATE/jules_task.yml"

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,6 @@
 # AI Coding Workflow Starter Kit for Jules
 
-[English](./README.md) · [한국어](./README.ko.md) · [기여하기](./CONTRIBUTING.md)
+[English](./README.md) · [한국어](./README.ko.md) · [기여하기](./CONTRIBUTING.md) · [보안](./SECURITY.md)
 
 > 대부분의 AI 코딩 데모는 완성된 코드만 보여줍니다.  
 > 이 프로젝트는 그 과정 자체를 보여줍니다.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Coding Workflow Starter Kit for Jules
 
-[English](./README.md) · [한국어](./README.ko.md) · [Contributing](./CONTRIBUTING.md)
+[English](./README.md) · [한국어](./README.ko.md) · [Contributing](./CONTRIBUTING.md) · [Security](./SECURITY.md)
 
 > Most AI coding demos show only the final code.  
 > This project shows the process.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+This project is a starter kit and template repository. We generally only provide security updates for the latest version on the `main` branch.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+**Do not use public GitHub issues for security vulnerabilities.**
+
+If you discover a security-sensitive issue, please report it through the following channels:
+
+1.  **GitHub Private Vulnerability Reporting:** If enabled for this repository, please use the "Report a vulnerability" button under the "Security" tab.
+2.  **Contact Maintainers:** If private reporting is not available, please contact the repository maintainers directly if a private communication channel is provided in their profile.
+
+### What to Include in a Report
+
+-   A description of the vulnerability.
+-   The potential impact of the vulnerability.
+-   Steps to reproduce (if applicable).
+-   Suggested mitigation (if known).
+
+### What NOT to Include
+
+-   **Do not** include full exploit code or proof-of-concepts in a public issue.
+-   **Do not** disclose sensitive credentials, tokens, or environment data.
+
+## Response Expectations
+
+We will acknowledge receipt of your report as soon as possible. Please keep in mind that this is a community-driven starter kit, and we cannot guarantee immediate fixes or specific response times.
+
+## Review of Security Changes
+
+Any pull requests related to security (e.g., updating dependencies with known vulnerabilities or changing security-related workflows) MUST be reviewed by a human maintainer. AI agents like Jules are not permitted to self-merge security-related changes.


### PR DESCRIPTION
### Problem
This repository lacked a security policy for contributors to report security-sensitive issues.

### Scope
- Created `SECURITY.md`.
- Updated `README.md` and `README.ko.md` with navigation links.
- Updated `.github/workflows/docs-and-templates.yml` to enforce the presence of `SECURITY.md`.

### Content of SECURITY.md
- Supported versions (main branch).
- Instructions on how to report vulnerabilities privately (GitHub Private Vulnerability Reporting or direct maintainer contact).
- Guidelines on what to include/exclude in reports.
- Realistic response expectations.
- Requirement for human review of security-related changes.

### Validation
- **Markdown Hygiene:** Verified files end with a newline and have no tab characters or unexpected trailing spaces.
- **Structural Integrity:** Confirmed `SECURITY.md` exists and is tracked by the starter kit validation logic.
- **CI Readiness:** Local run of the validation script passed for all modified files.

Closes # [Insert Issue Number here if applicable]

Fixes #15

---
*PR created automatically by Jules for task [1395076839640345296](https://jules.google.com/task/1395076839640345296) started by @hkimw*