### PR TITLE
[Jules] Add MIT LICENSE for the starter kit

### DIFF
--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -110,6 +110,7 @@ jobs:
             "README.md"
             "README.ko.md"
             "CONTRIBUTING.md"
+            "LICENSE"
             "AGENTS.md"
             ".github/PULL_REQUEST_TEMPLATE.md"
             ".github/ISSUE_TEMPLATE/jules_task.yml"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hyunwoo Kim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.ko.md
+++ b/README.ko.md
@@ -223,3 +223,9 @@ History.
 ```
 
 진짜 AI-assisted engineering은 여기서 일어납니다.
+
+---
+
+## 라이선스
+
+이 프로젝트는 [MIT 라이선스](./LICENSE)를 따릅니다.

--- a/README.md
+++ b/README.md
@@ -223,3 +223,9 @@ History.
 ```
 
 That is where real AI-assisted engineering happens.
+
+---
+
+## License
+
+This project is licensed under the [MIT License](./LICENSE).


### PR DESCRIPTION
Closes #13

**Jules Validation Notes (AI Agent)**
- Created `LICENSE` file containing the standard MIT License text.
- Appended a relative link to the `LICENSE` file at the bottom of both `README.md` and `README.ko.md` to keep documentation in sync.
- Updated `.github/workflows/docs-and-templates.yml` to include `"LICENSE"` in the list of required starter kit files.
- Locally validated changes using bash scripts mirroring CI constraints: verified no tabs, correct trailing spaces, and correct EOF newlines for Markdown files.
- Confirmed the file structure meets updated required paths constraints.

---
*PR created automatically by Jules for task [14668832109198372654](https://jules.google.com/task/14668832109198372654) started by @hkimw*