### PR TITLE
Add SECURITY.md

### DIFF
--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -111,6 +111,7 @@ jobs:
             "README.ko.md"
             "CONTRIBUTING.md"
             "CODE_OF_CONDUCT.md"
+            "SECURITY.md"
             "LICENSE"
             "AGENTS.md"
             ".github/PULL_REQUEST_TEMPLATE.md"

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,6 @@
 # AI Coding Workflow Starter Kit for Jules
 
-[English](./README.md) · [한국어](./README.ko.md) · [기여하기](./CONTRIBUTING.md) · [행동 강령](./CODE_OF_CONDUCT.md)
+[English](./README.md) · [한국어](./README.ko.md) · [기여하기](./CONTRIBUTING.md) · [행동 강령](./CODE_OF_CONDUCT.md) · [보안](./SECURITY.md)
 
 > 대부분의 AI 코딩 데모는 완성된 코드만 보여줍니다.  
 > 이 프로젝트는 그 과정 자체를 보여줍니다.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Coding Workflow Starter Kit for Jules
 
-[English](./README.md) · [한국어](./README.ko.md) · [Contributing](./CONTRIBUTING.md) · [Code of Conduct](./CODE_OF_CONDUCT.md)
+[English](./README.md) · [한국어](./README.ko.md) · [Contributing](./CONTRIBUTING.md) · [Code of Conduct](./CODE_OF_CONDUCT.md) · [Security](./SECURITY.md)
 
 > Most AI coding demos show only the final code.  
 > This project shows the process.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+Only the `main` branch is actively supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| `main`  | :white_check_mark: |
+| others  | :x:                |
+
+## Reporting a Vulnerability
+
+Please do not report security-sensitive issues via public GitHub issues.
+
+To report a vulnerability, please contact the project maintainers directly via email. You can find contact information in the maintainers' GitHub profiles.
+
+Please include the following in your report:
+- A description of the vulnerability.
+- Steps to reproduce the vulnerability.
+- Any potential impact.
+
+## Response Expectations
+
+We will attempt to acknowledge receipt of your vulnerability report as soon as possible. However, since this project is managed by volunteers, we cannot guarantee an immediate response. We will provide updates as we investigate the issue.
+
+## Security-Related Workflow Changes
+
+Because this project manages an AI coding agent workflow, changes to automation that could impact repository security require careful review.
+Any security-related workflow changes must be explicitly reviewed by a human maintainer before being merged. Do not bypass human review for workflow modifications.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,6 +16,7 @@ Please do not report security-sensitive issues via public GitHub issues.
 To report a vulnerability, please contact the project maintainers directly via email. You can find contact information in the maintainers' GitHub profiles.
 
 Please include the following in your report:
+
 - A description of the vulnerability.
 - Steps to reproduce the vulnerability.
 - Any potential impact.
@@ -27,4 +28,4 @@ We will attempt to acknowledge receipt of your vulnerability report as soon as p
 ## Security-Related Workflow Changes
 
 Because this project manages an AI coding agent workflow, changes to automation that could impact repository security require careful review.
-Any security-related workflow changes must be explicitly reviewed by a human maintainer before being merged. Do not bypass human review for workflow modifications.
+Any security-related workflow changes must be explicitly reviewed by a human maintainer before being merged.


### PR DESCRIPTION
Validation:
- `SECURITY.md` was added.
- Link is relative and correct (`[Security](./SECURITY.md)` and `[보안](./SECURITY.md)`).
- Docs CI scripts were executed locally and pass.

(Note: AI assisted contribution)

---
*PR created automatically by Jules for task [11018448352099433751](https://jules.google.com/task/11018448352099433751) started by @hkimw*