### PR TITLE
Polish README for awesome-list readiness

### DIFF
--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -120,6 +120,8 @@ jobs:
             "docs/workflows/workflow-levels.md"
             "docs/experiments/no-human-only-jules-workflow.md"
             "docs/experiments/jules-alpha-evolve.md"
+            "docs/case-studies/digital-logic-circuit.md"
+            "docs/case-studies/english-only-project.md"
             "prompts/issue-to-jules-task.md"
             "prompts/daily-maintainer-report.md"
             "examples/issues/README.md"

--- a/README.ko.md
+++ b/README.ko.md
@@ -5,41 +5,81 @@
 > 대부분의 AI 코딩 데모는 완성된 코드만 보여줍니다.  
 > 이 프로젝트는 그 과정 자체를 보여줍니다.
 
-**AI Coding Workflow Starter Kit for Jules**는 Jules를 GitHub Issue, Pull Request, Review, CI, case study, controlled automation 안에서 운영하기 위한 GitHub-native playbook입니다.
+**AI Coding Workflow Starter Kit for Jules**는 Jules를 GitHub Issue, Pull Request, Review, CI, case study, controlled automation 안에서 운영하기 위한 GitHub-native starter kit입니다.
 
-이 저장소는 단순한 prompt 모음이 아닙니다. AI-assisted work가 읽을 수 있는 engineering history를 남기도록 돕는 reusable starter kit입니다.
-
-Repository: <https://github.com/hkimw-underground/vibe-coding-with-jules>
-
-권장 public positioning:
+이 저장소는 AI-assisted work가 읽을 수 있는 engineering history를 남기도록 돕습니다.
 
 ```text
-Repo name: jules-workflow-starter-kit
-Display title: AI Coding Workflow Starter Kit for Jules
-Tagline: Most AI coding demos show only the final code. This project shows the process.
+Issue → Jules task → Pull request → CI → Human review → Merge
 ```
+
+단순한 prompt 모음이 아니라 template, example, review checklist, CI gate, case study를 포함한 reusable workflow kit입니다.
 
 ---
 
-## What This Is
+## What You Get
 
-이 저장소는 Jules를 일반적인 GitHub 개발 관행 안에서 운영하기 위한 template과 예시를 제공합니다.
-
-- scoped GitHub Issues
-- Jules task handoff prompts
-- small pull requests
-- human review checklists
-- CI-first validation
-- case study documentation
-- controlled automation experiments
+- Jules task를 위한 scoped GitHub Issue template
+- linked issue와 validation notes를 요구하는 PR template
+- approve/request changes용 maintainer review example
+- Markdown, YAML, required starter kit file을 확인하는 lightweight CI
+- human-led workflow부터 sandbox-only automation experiment까지 나눈 workflow levels
+- issue handoff와 daily maintainer report용 prompt
+- 실제 프로젝트에 workflow를 적용한 case study
 
 핵심 메시지는 단순합니다.
 
-> Human maintainer가 AI coding agent를 GitHub-native engineering practice 안에서 리드한다.
+> Human maintainer가 AI coding agent를 일반적인 GitHub engineering practice 안에서 리드한다.
 
 아래 메시지가 아닙니다.
 
 > AI가 프로젝트 전체를 혼자 만들었다.
+
+---
+
+## Start Here
+
+### 1. Starter Kit 파일 복사하기
+
+자기 repository에 먼저 아래 파일들을 복사합니다.
+
+```text
+AGENTS.md
+.github/ISSUE_TEMPLATE/
+.github/PULL_REQUEST_TEMPLATE.md
+.github/workflows/docs-and-templates.yml
+prompts/
+examples/
+```
+
+### 2. 작은 Issue 하나 열기
+
+좋은 issue:
+
+```text
+Add a PR template that requires a linked issue, validation steps, and a reviewer checklist.
+```
+
+나쁜 issue:
+
+```text
+Improve the project.
+```
+
+### 3. Issue를 Jules에게 넘기기
+
+Issue를 source of truth로 사용합니다. Jules는 issue를 대체하는 것이 아니라 focused PR을 만들어야 합니다.
+
+### 4. Merge 전 Review하기
+
+Merge 전에 다음을 확인합니다.
+
+- PR이 linked issue를 해결하는가?
+- scope가 통제되어 있는가?
+- 관련 없는 파일이 바뀌지 않았는가?
+- tests 또는 validation steps가 포함되어 있는가?
+- CI가 통과하는가?
+- 나중에 다른 개발자가 이 history를 이해할 수 있는가?
 
 ---
 
@@ -60,32 +100,6 @@ Tagline: Most AI coding demos show only the final code. This project shows the p
 
 ---
 
-## Core Workflow
-
-```text
-Human maintainer가 scoped GitHub Issue 작성
-        ↓
-Jules가 task 구현
-        ↓
-Jules가 focused PR 생성 또는 publish
-        ↓
-CI가 변경 사항 검증
-        ↓
-Human maintainer가 diff review
-        ↓
-Maintainer가 merge 또는 수정 요청
-```
-
-이 workflow는 과정을 GitHub history에 남깁니다.
-
-```text
-Issue → Jules task → PR → Review → CI → Merge
-```
-
-나중에 다른 개발자가 history를 이해할 수 없다면 workflow가 실패한 것입니다.
-
----
-
 ## Repository Structure
 
 ```text
@@ -93,10 +107,16 @@ Issue → Jules task → PR → Review → CI → Merge
 ├── README.md
 ├── README.ko.md
 ├── AGENTS.md
+├── CONTRIBUTING.md
+├── CODE_OF_CONDUCT.md
+├── SECURITY.md
+├── LICENSE
 ├── .github/
 │   ├── ISSUE_TEMPLATE/
 │   │   ├── jules_task.yml
 │   │   └── workflow_experiment.yml
+│   ├── workflows/
+│   │   └── docs-and-templates.yml
 │   └── PULL_REQUEST_TEMPLATE.md
 ├── examples/
 │   ├── issues/
@@ -117,72 +137,21 @@ Issue → Jules task → PR → Review → CI → Merge
 
 ---
 
-## Getting Started
-
-### 1. Starter Kit 복사하기
-
-프로젝트에 필요한 부분을 복사합니다.
-
-```text
-AGENTS.md
-.github/ISSUE_TEMPLATE/
-.github/PULL_REQUEST_TEMPLATE.md
-examples/
-docs/workflows/
-prompts/
-```
-
-### 2. Jules 연결하기
-
-Jules에서 GitHub repository 연결을 확인합니다.
-
-### 3. 작은 Issue 하나로 시작하기
-
-좋은 issue:
-
-```text
-Add a PR template that requires linked issue, validation steps, and reviewer checklist.
-```
-
-나쁜 issue:
-
-```text
-Improve the project.
-```
-
-### 4. Jules에게 Focused PR 요청하기
-
-Issue를 source of truth로 사용합니다. Jules prompt는 issue를 reviewable PR로 바꾸는 역할을 해야지, issue 자체를 대체하면 안 됩니다.
-
-### 5. Merge 전 Review하기
-
-Merge 전에 다음을 확인합니다.
-
-- PR이 linked issue를 해결하는가?
-- scope가 통제되어 있는가?
-- 관련 없는 파일이 바뀌지 않았는가?
-- tests 또는 validation steps가 포함되어 있는가?
-- CI가 통과하는가?
-- 구현이 유지보수 가능한가?
-- 나중에 다른 개발자가 이 history를 이해할 수 있는가?
-
----
-
 ## Case Studies
 
 ### [Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)
 
 Repository: <https://github.com/hkimw-underground/digital-logic-circuit>
 
-실제 hardware/software capstone case study입니다. 외부 project tracker에 있던 planning과 implementation workflow를 GitHub Issues, PRs, human review, Jules-assisted implementation 중심으로 옮기는 사례입니다.
+실제 hardware/software capstone case study입니다. planning과 implementation을 GitHub Issues, PRs, human review, Jules-assisted implementation 중심으로 옮기는 사례입니다.
 
 Architecture, hardware constraints, scope, review, final merge decision은 maintainer가 책임집니다.
 
-### Case Study B: English-Only Open Source Project
+### [Case Study B: English-Only Open Source Project](./docs/case-studies/english-only-project.md)
 
 Status: planned.
 
-글로벌 독자를 위한 순수 영어 오픈소스 사례입니다. 학교/capstone 맥락 밖에서도 small issues, focused Jules PRs, CI-first development, readable review comments가 재사용 가능하다는 것을 보여주는 목적입니다.
+글로벌 독자를 위한 예정된 순수 영어 case study입니다. 학교/capstone 맥락 밖에서도 small issues, focused Jules PRs, CI-first development, readable review comments가 재사용 가능하다는 것을 보여주는 목적입니다.
 
 ---
 
@@ -210,7 +179,7 @@ Evaluator-driven evolution must use measurable tests or benchmarks.
 
 ---
 
-## Core Message
+## Why This Exists
 
 대부분의 AI coding demo는 완성된 코드만 보여줍니다.
 

--- a/README.md
+++ b/README.md
@@ -5,41 +5,81 @@
 > Most AI coding demos show only the final code.  
 > This project shows the process.
 
-**AI Coding Workflow Starter Kit for Jules** is a GitHub-native playbook for leading Jules through issues, pull requests, reviews, CI, case studies, and controlled automation.
+**AI Coding Workflow Starter Kit for Jules** is a GitHub-native starter kit for leading Jules through issues, pull requests, reviews, CI, case studies, and controlled automation.
 
-This is not a prompt dump. It is a reusable starter kit for maintainers who want AI-assisted work to leave a clean engineering history.
-
-Repository: <https://github.com/hkimw-underground/vibe-coding-with-jules>
-
-Suggested public positioning:
+It is built for maintainers who want AI-assisted work to leave a clean engineering history:
 
 ```text
-Repo name: jules-workflow-starter-kit
-Display title: AI Coding Workflow Starter Kit for Jules
-Tagline: Most AI coding demos show only the final code. This project shows the process.
+Issue → Jules task → Pull request → CI → Human review → Merge
 ```
+
+This is not a prompt dump. It is a reusable workflow kit with templates, examples, review checklists, CI gates, and case studies.
 
 ---
 
-## What This Is
+## What You Get
 
-This repository provides reusable templates and examples for running Jules inside normal GitHub development practice:
+- scoped GitHub Issue templates for Jules tasks
+- PR templates that require linked issues and validation notes
+- maintainer review examples for approving or requesting changes
+- lightweight CI checks for Markdown, YAML, and required starter kit files
+- workflow levels from human-led work to sandbox-only automation experiments
+- prompts for issue handoff and daily maintainer reports
+- case studies showing how the workflow applies to real projects
 
-- scoped GitHub Issues
-- Jules task handoff prompts
-- small pull requests
-- human review checklists
-- CI-first validation
-- case study documentation
-- controlled automation experiments
+The core idea is simple:
 
-The core message is simple:
-
-> A human maintainer leads an AI coding agent through GitHub-native engineering practices.
+> A human maintainer leads an AI coding agent through normal GitHub engineering practice.
 
 Not:
 
 > AI built the whole project by itself.
+
+---
+
+## Start Here
+
+### 1. Copy the Starter Kit Files
+
+Start with these files in your own repository:
+
+```text
+AGENTS.md
+.github/ISSUE_TEMPLATE/
+.github/PULL_REQUEST_TEMPLATE.md
+.github/workflows/docs-and-templates.yml
+prompts/
+examples/
+```
+
+### 2. Open a Small Issue
+
+Good issue:
+
+```text
+Add a PR template that requires a linked issue, validation steps, and a reviewer checklist.
+```
+
+Bad issue:
+
+```text
+Improve the project.
+```
+
+### 3. Hand the Issue to Jules
+
+Use the issue as the source of truth. Jules should produce a focused PR, not replace the issue.
+
+### 4. Review Before Merge
+
+Before merging, check:
+
+- Does the PR solve the linked issue?
+- Is the scope controlled?
+- Are unrelated files changed?
+- Are tests or validation steps included?
+- Does CI pass?
+- Would another developer understand this history later?
 
 ---
 
@@ -60,32 +100,6 @@ The default workflow is Level 1. Levels 5 and 6 belong in sandboxes, not unprote
 
 ---
 
-## Core Workflow
-
-```text
-Human maintainer opens a scoped GitHub Issue
-        ↓
-Jules implements the task
-        ↓
-Jules opens or publishes a focused PR
-        ↓
-CI validates the change
-        ↓
-Human maintainer reviews the diff
-        ↓
-Maintainer merges or requests changes
-```
-
-This keeps the process visible:
-
-```text
-Issue → Jules task → PR → Review → CI → Merge
-```
-
-If another developer cannot understand the history later, the workflow failed.
-
----
-
 ## Repository Structure
 
 ```text
@@ -93,10 +107,16 @@ If another developer cannot understand the history later, the workflow failed.
 ├── README.md
 ├── README.ko.md
 ├── AGENTS.md
+├── CONTRIBUTING.md
+├── CODE_OF_CONDUCT.md
+├── SECURITY.md
+├── LICENSE
 ├── .github/
 │   ├── ISSUE_TEMPLATE/
 │   │   ├── jules_task.yml
 │   │   └── workflow_experiment.yml
+│   ├── workflows/
+│   │   └── docs-and-templates.yml
 │   └── PULL_REQUEST_TEMPLATE.md
 ├── examples/
 │   ├── issues/
@@ -117,72 +137,21 @@ If another developer cannot understand the history later, the workflow failed.
 
 ---
 
-## Getting Started
-
-### 1. Copy the Starter Kit
-
-Copy the parts that match your project:
-
-```text
-AGENTS.md
-.github/ISSUE_TEMPLATE/
-.github/PULL_REQUEST_TEMPLATE.md
-examples/
-docs/workflows/
-prompts/
-```
-
-### 2. Connect Jules
-
-Use Jules to connect the GitHub repository and confirm that Jules can access the target repo.
-
-### 3. Start with One Small Issue
-
-Good issue:
-
-```text
-Add a PR template that requires linked issue, validation steps, and reviewer checklist.
-```
-
-Bad issue:
-
-```text
-Improve the project.
-```
-
-### 4. Ask Jules for a Focused PR
-
-Use the issue as the source of truth. A Jules prompt should convert the issue into a reviewable PR, not replace the issue.
-
-### 5. Review Before Merge
-
-Before merging, check:
-
-- Does the PR solve the linked issue?
-- Is the scope controlled?
-- Are unrelated files changed?
-- Are tests or validation steps included?
-- Does CI pass?
-- Is the implementation maintainable?
-- Would another developer understand this history later?
-
----
-
 ## Case Studies
 
 ### [Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)
 
 Repository: <https://github.com/hkimw-underground/digital-logic-circuit>
 
-This is a real hardware/software capstone case study. It shows how planning and implementation can move from an external project tracker into GitHub Issues, PRs, human review, and Jules-assisted implementation.
+A real hardware/software capstone case study showing how planning and implementation can move into GitHub Issues, PRs, human review, and Jules-assisted implementation.
 
 The maintainer owns architecture, hardware constraints, scope, review, and final merge decisions.
 
-### Case Study B: English-Only Open Source Project
+### [Case Study B: English-Only Open Source Project](./docs/case-studies/english-only-project.md)
 
 Status: planned.
 
-This will be a clean English-only project for a global audience. It should demonstrate small issues, focused Jules PRs, CI-first development, and readable review comments outside a school/capstone context.
+A planned English-only case study for a global audience. It will demonstrate the same workflow outside a school/capstone context: small issues, focused Jules PRs, CI-first development, and readable review comments.
 
 ---
 
@@ -210,7 +179,7 @@ Evaluator-driven evolution must use measurable tests or benchmarks.
 
 ---
 
-## Core Message
+## Why This Exists
 
 Most AI coding demos show only the final code.
 

--- a/docs/case-studies/english-only-project.md
+++ b/docs/case-studies/english-only-project.md
@@ -1,0 +1,52 @@
+# Case Study B: English-Only Open Source Project
+
+Status: planned.
+
+This case study will document a clean English-only open-source project using the same Jules workflow shown in this starter kit.
+
+## Purpose
+
+Case Study B exists to show that the workflow is reusable outside a school or capstone context.
+
+It should demonstrate:
+
+- small GitHub Issues
+- focused Jules pull requests
+- CI-first development
+- readable human review comments
+- clear separation between AI agent work and maintainer ownership
+
+## Selection Criteria
+
+A good Case Study B candidate should:
+
+- be understandable to a global open-source audience
+- have a small but real implementation surface
+- support automated tests or lightweight CI
+- allow issues to be completed through small PRs
+- avoid private, school-specific, or organization-specific context
+- keep Jules framed as an AI coding agent, not a human contributor
+
+## Expected Workflow
+
+```text
+Issue → Jules task → Pull request → CI → Human review → Merge
+```
+
+## Non-goals
+
+This case study should not be used to demonstrate fully autonomous development.
+
+It should not mix unrelated goals such as branding, large architecture rewrites, or product strategy.
+
+## Maintainer Notes
+
+When this case study is selected, replace this placeholder with:
+
+- repository link
+- project summary
+- selected issues
+- representative Jules PRs
+- review examples
+- CI results
+- lessons learned


### PR DESCRIPTION
## Summary

Closes #23

Polishes the README for a more public-facing starter kit presentation and fixes the missing Case Study B reference.

## Workflow Level

- [x] Level 1: Human-led Jules workflow
- [ ] Level 2: Semi-autonomous Jules workflow
- [ ] Level 3: Human issue only
- [ ] Level 4: Daily agentic maintainer loop
- [ ] Experiment: no-human sandbox or evaluator-driven evolution

## Changes

- Remove internal planning language from `README.md` and `README.ko.md`.
- Make the first screen more directly useful for external readers.
- Move the copy-first guidance higher in the README.
- Add `docs/case-studies/english-only-project.md` as a planned Case Study B placeholder.
- Update docs CI required paths to include both case study files.

## Validation

- [x] README links are relative.
- [x] Case Study B placeholder exists where README links point.
- [x] English and Korean README structure remains aligned.
- [x] Docs CI is expected to validate Markdown, YAML, and required starter kit structure.

## Scope Control

- [x] This PR only changes README polish, Case Study B placeholder consistency, and docs CI required paths.
- [x] No automation behavior was changed.
- [x] No community standard files were changed.

Assumptions:

```text
Case Study B should remain a planned placeholder until the English-only repository is selected.
```
