### PR TITLE
[Jules Task] Polish README for awesome-list readiness

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -11,14 +11,6 @@
 
 Repository: <https://github.com/hkimw-underground/vibe-coding-with-jules>
 
-권장 public positioning:
-
-```text
-Repo name: jules-workflow-starter-kit
-Display title: AI Coding Workflow Starter Kit for Jules
-Tagline: Most AI coding demos show only the final code. This project shows the process.
-```
-
 ---
 
 ## What This Is
@@ -124,9 +116,12 @@ Issue → Jules task → PR → Review → CI → Merge
 프로젝트에 필요한 부분을 복사합니다.
 
 ```text
+# Core files
 AGENTS.md
 .github/ISSUE_TEMPLATE/
 .github/PULL_REQUEST_TEMPLATE.md
+
+# Optional reference materials
 examples/
 docs/workflows/
 prompts/
@@ -178,7 +173,7 @@ Repository: <https://github.com/hkimw-underground/digital-logic-circuit>
 
 Architecture, hardware constraints, scope, review, final merge decision은 maintainer가 책임집니다.
 
-### Case Study B: English-Only Open Source Project
+### [Case Study B: English-Only Open Source Project](./docs/case-studies/english-only-project.md)
 
 Status: planned.
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,6 @@ This is not a prompt dump. It is a reusable starter kit for maintainers who want
 
 Repository: <https://github.com/hkimw-underground/vibe-coding-with-jules>
 
-Suggested public positioning:
-
-```text
-Repo name: jules-workflow-starter-kit
-Display title: AI Coding Workflow Starter Kit for Jules
-Tagline: Most AI coding demos show only the final code. This project shows the process.
-```
-
 ---
 
 ## What This Is
@@ -124,9 +116,12 @@ If another developer cannot understand the history later, the workflow failed.
 Copy the parts that match your project:
 
 ```text
+# Core files
 AGENTS.md
 .github/ISSUE_TEMPLATE/
 .github/PULL_REQUEST_TEMPLATE.md
+
+# Optional reference materials
 examples/
 docs/workflows/
 prompts/
@@ -178,7 +173,7 @@ This is a real hardware/software capstone case study. It shows how planning and 
 
 The maintainer owns architecture, hardware constraints, scope, review, and final merge decisions.
 
-### Case Study B: English-Only Open Source Project
+### [Case Study B: English-Only Open Source Project](./docs/case-studies/english-only-project.md)
 
 Status: planned.
 

--- a/docs/case-studies/english-only-project.md
+++ b/docs/case-studies/english-only-project.md
@@ -1,0 +1,5 @@
+# Case Study B: English-Only Open Source Project
+
+**Status:** Planned
+
+This will be a clean English-only project for a global audience. It should demonstrate small issues, focused Jules PRs, CI-first development, and readable review comments outside a school/capstone context.


### PR DESCRIPTION
Fixes #23.

This PR prepares the repository to be "awesome-list ready" by making the documentation feel more public-facing and reusable as a starter kit.

**Scope**
- `README.md`
- `README.ko.md`
- `docs/case-studies/english-only-project.md`

**Validation**
- Verified the `docs/case-studies/english-only-project.md` file contains placeholder text.
- Verified README links are relative and point correctly to Case Study B placeholder.
- Validated that English and Korean README structures remain aligned and identical.
- Validated markdown hygiene (no tabs, ends with newline, standard trailing spaces).
- Checked YAML syntax.
- Verified starter kit structure using rules from `.github/workflows/docs-and-templates.yml`. All local checks pass.

---
*PR created automatically by Jules for task [5914855993694758721](https://jules.google.com/task/5914855993694758721) started by @hkimw*