### PR TITLE
Add reusable example issues and PR reviews

### DIFF
--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -122,6 +122,8 @@ jobs:
             "docs/experiments/jules-alpha-evolve.md"
             "prompts/issue-to-jules-task.md"
             "prompts/daily-maintainer-report.md"
+            "examples/issues/README.md"
+            "examples/pr-reviews/README.md"
           )
 
           for path in "${required_paths[@]}"; do

--- a/README.ko.md
+++ b/README.ko.md
@@ -107,6 +107,9 @@ Issue → Jules task → PR → Review → CI → Merge
 │   └── case-studies/
 │       ├── digital-logic-circuit.md
 │       └── english-only-project.md
+├── examples/
+│   ├── issues/
+│   └── pr-reviews/
 └── prompts/
     ├── issue-to-jules-task.md
     └── daily-maintainer-report.md
@@ -125,6 +128,7 @@ AGENTS.md
 .github/ISSUE_TEMPLATE/
 .github/PULL_REQUEST_TEMPLATE.md
 docs/workflows/
+examples/
 prompts/
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ If another developer cannot understand the history later, the workflow failed.
 │   └── case-studies/
 │       ├── digital-logic-circuit.md
 │       └── english-only-project.md
+├── examples/
+│   ├── issues/
+│   └── pr-reviews/
 └── prompts/
     ├── issue-to-jules-task.md
     └── daily-maintainer-report.md
@@ -125,6 +128,7 @@ AGENTS.md
 .github/ISSUE_TEMPLATE/
 .github/PULL_REQUEST_TEMPLATE.md
 docs/workflows/
+examples/
 prompts/
 ```
 

--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -1,0 +1,15 @@
+# Example Issues
+
+This directory contains examples of well-scoped GitHub Issues designed for a Jules workflow.
+
+When creating issues for Jules, you should prioritize:
+- Clear boundaries (what is in scope vs out of scope)
+- Explicit non-goals
+- Concrete acceptance criteria
+- Expected validation steps
+
+These examples can be copied and adapted for your own project:
+
+- [docs-task.md](./docs-task.md): A simple documentation update task.
+- [ci-task.md](./ci-task.md): A workflow or CI/CD task.
+- [refactor-task.md](./refactor-task.md): A code refactoring task with specific boundaries.

--- a/examples/issues/ci-task.md
+++ b/examples/issues/ci-task.md
@@ -1,0 +1,30 @@
+# [Jules Task] Add Python 3.12 to test matrix
+
+## Problem
+
+Python 3.12 was released recently, but our GitHub Actions test suite only runs against Python 3.10 and 3.11. We need to ensure our library is compatible with 3.12.
+
+## Scope
+
+- Update `.github/workflows/test.yml` to include `3.12` in the `python-version` matrix.
+- Ensure any `actions/setup-python` steps are compatible with 3.12 (e.g., using `v5`).
+
+## Non-goals
+
+- Do not update the minimum required Python version in `setup.py` or `pyproject.toml` (we still support 3.10).
+- Do not fix code deprecation warnings in this PR; we will handle those in a separate task.
+
+## Acceptance Criteria
+
+- [ ] `test.yml` includes Python 3.12 in the matrix.
+- [ ] GitHub Actions syntax is valid.
+
+## Validation
+
+The PR should confirm:
+- The YAML syntax passes validation.
+- The CI workflow triggers successfully on the PR and passes for all three Python versions.
+
+## Jules Instructions
+
+Focus only on updating the CI configuration. Do not modify application code. If tests fail on 3.12 due to our code, mention it in the PR description but do not attempt to fix it in this PR.

--- a/examples/issues/docs-task.md
+++ b/examples/issues/docs-task.md
@@ -1,0 +1,36 @@
+# [Jules Task] Update README with new configuration options
+
+## Problem
+
+The new `v2.0` release added three new configuration options (`max_retries`, `timeout_ms`, `fallback_url`), but these are not documented in the main `README.md`. Users are confused about how to configure the client properly.
+
+## Scope
+
+- Update the "Configuration" section in `README.md`.
+- Add a new table or list explaining:
+  - `max_retries` (default: 3)
+  - `timeout_ms` (default: 5000)
+  - `fallback_url` (optional, no default)
+- Ensure the Markdown formatting matches the existing document.
+
+## Non-goals
+
+- Do not update `CHANGELOG.md`.
+- Do not refactor the existing configuration code.
+- Do not translate the changes to other languages yet.
+
+## Acceptance Criteria
+
+- [ ] `README.md` includes the three new options.
+- [ ] Defaults are clearly stated.
+- [ ] Markdown hygiene passes (no trailing spaces, correct heading levels).
+
+## Validation
+
+The PR should confirm:
+- `README.md` renders correctly locally.
+- Markdown linter passes (`npm run lint:md`).
+
+## Jules Instructions
+
+Create a PR focusing strictly on updating `README.md`. Do not modify source code or translation files.

--- a/examples/issues/refactor-task.md
+++ b/examples/issues/refactor-task.md
@@ -1,0 +1,34 @@
+# [Jules Task] Extract string formatting logic to a utility module
+
+## Problem
+
+The `src/report_generator.ts` file has become too large. It contains several helper functions for formatting dates and currencies that are mixed in with the core report generation logic.
+
+## Scope
+
+- Create a new file: `src/utils/formatters.ts`.
+- Move the `formatDate`, `formatCurrency`, and `capitalizeTitle` functions from `src/report_generator.ts` to `src/utils/formatters.ts`.
+- Export these functions and import them back into `src/report_generator.ts`.
+- Update any corresponding test imports if necessary.
+
+## Non-goals
+
+- Do not change the behavior of the formatting functions.
+- Do not add new formatting features.
+- Do not refactor other parts of `report_generator.ts`.
+
+## Acceptance Criteria
+
+- [ ] Formatting logic is isolated in `src/utils/formatters.ts`.
+- [ ] `src/report_generator.ts` uses the imported functions.
+- [ ] Existing unit tests pass without modifying the test assertions.
+
+## Validation
+
+The PR should confirm:
+- The project builds successfully (`npm run build`).
+- All tests pass (`npm run test`).
+
+## Jules Instructions
+
+Perform a pure refactor. The public API of the functions should not change. Ensure you run the test suite to verify no regressions were introduced.

--- a/examples/pr-reviews/README.md
+++ b/examples/pr-reviews/README.md
@@ -1,0 +1,16 @@
+# Example PR Reviews
+
+This directory contains examples of human maintainer reviews on Pull Requests created by Jules.
+
+When reviewing Jules PRs, you should:
+- Verify the PR exactly matches the scope of the linked issue.
+- Ensure validation steps have been documented in the PR description.
+- Check that no unrelated files were modified.
+- Leave clear, actionable comments if changes are needed.
+- Remember you are guiding an AI agent, not another human developer.
+
+These examples demonstrate how to communicate effectively in a Jules workflow:
+
+- [approve.md](./approve.md): A standard approval when the PR meets all criteria.
+- [request-changes.md](./request-changes.md): Requesting a small fix when the scope was slightly missed.
+- [validation-needed.md](./validation-needed.md): Asking Jules to provide missing validation notes.

--- a/examples/pr-reviews/approve.md
+++ b/examples/pr-reviews/approve.md
@@ -1,0 +1,15 @@
+# Example: Approve PR
+
+**Context:** Jules has opened a PR that perfectly addresses the linked issue. The scope is tight, tests are passing, and validation notes are included in the description.
+
+---
+
+**Reviewer Action:** Approve Pull Request
+
+**Comment:**
+
+> Looks good. The implementation strictly follows the acceptance criteria in #42.
+>
+> I verified the validation notes, and CI is passing. No unrelated files were touched.
+>
+> Merging this now.

--- a/examples/pr-reviews/request-changes.md
+++ b/examples/pr-reviews/request-changes.md
@@ -1,0 +1,13 @@
+# Example: Request Changes (Scope Creep)
+
+**Context:** Jules has opened a PR that solves the issue but also includes an unrequested refactor of a neighboring function.
+
+---
+
+**Reviewer Action:** Request Changes
+
+**Comment:**
+
+> Jules, the fix for the `NullReferenceException` is correct. However, you also reformatted the `processUserData` function which was explicitly outside the scope of issue #15.
+>
+> Please revert the changes to `processUserData` so that this PR only contains the null check. Once that is reverted and the tests still pass, I will approve.

--- a/examples/pr-reviews/validation-needed.md
+++ b/examples/pr-reviews/validation-needed.md
@@ -1,0 +1,15 @@
+# Example: Request Changes (Missing Validation)
+
+**Context:** Jules has opened a PR, and the code looks correct, but the PR description does not include any notes on how the changes were verified before submission.
+
+---
+
+**Reviewer Action:** Request Changes
+
+**Comment:**
+
+> The code changes look correct according to issue #88.
+>
+> However, the PR description is missing validation notes. As per our `AGENTS.md` guidelines, please run the test suite locally to verify the new endpoint behaves as expected and update the PR description with the exact commands you ran and their output.
+>
+> I will review again once the validation notes are provided.


### PR DESCRIPTION
Add reusable example issues and PR reviews

Closes #21.

This PR adds a set of concrete examples to the starter kit demonstrating good Jules-ready issues and human maintainer reviews.

Changes included:
- Created `examples/issues/` with README and 3 example tasks (docs, CI, refactor).
- Created `examples/pr-reviews/` with README and 3 review examples (approve, request changes, validation needed).
- Updated English and Korean READMEs to link to the new examples.
- Updated docs CI workflow to require the new example READMEs.

Validation notes:
- Local Markdown hygiene script passed for all new files.
- Local YAML syntax script passed.
- Starter kit structure validation passed.

---
*PR created automatically by Jules for task [8781626418987574797](https://jules.google.com/task/8781626418987574797) started by @hkimw*