### PR TITLE
Polish READMEs for awesome-list readiness

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -5,19 +5,7 @@
 > 대부분의 AI 코딩 데모는 완성된 코드만 보여줍니다.  
 > 이 프로젝트는 그 과정 자체를 보여줍니다.
 
-**AI Coding Workflow Starter Kit for Jules**는 Jules를 GitHub Issue, Pull Request, Review, CI, case study, controlled automation 안에서 운영하기 위한 GitHub-native playbook입니다.
-
-이 저장소는 단순한 prompt 모음이 아닙니다. AI-assisted work가 읽을 수 있는 engineering history를 남기도록 돕는 reusable starter kit입니다.
-
-Repository: <https://github.com/hkimw-underground/vibe-coding-with-jules>
-
-권장 public positioning:
-
-```text
-Repo name: jules-workflow-starter-kit
-Display title: AI Coding Workflow Starter Kit for Jules
-Tagline: Most AI coding demos show only the final code. This project shows the process.
-```
+**AI Coding Workflow Starter Kit for Jules**는 AI-assisted work가 읽을 수 있는 engineering history를 남기도록 돕는 reusable starter kit입니다. Jules를 GitHub Issue, Pull Request, Review, CI, case study, controlled automation 안에서 운영하기 위한 템플릿을 제공합니다.
 
 ---
 
@@ -121,7 +109,7 @@ Issue → Jules task → PR → Review → CI → Merge
 
 ### 1. Starter Kit 복사하기
 
-프로젝트에 필요한 부분을 복사합니다.
+시작하려면 다음 폴더와 파일들을 자신의 저장소에 직접 복사하세요:
 
 ```text
 AGENTS.md
@@ -178,7 +166,7 @@ Repository: <https://github.com/hkimw-underground/digital-logic-circuit>
 
 Architecture, hardware constraints, scope, review, final merge decision은 maintainer가 책임집니다.
 
-### Case Study B: English-Only Open Source Project
+### [Case Study B: English-Only Open Source Project](./docs/case-studies/english-only-project.md)
 
 Status: planned.
 

--- a/README.md
+++ b/README.md
@@ -5,19 +5,7 @@
 > Most AI coding demos show only the final code.  
 > This project shows the process.
 
-**AI Coding Workflow Starter Kit for Jules** is a GitHub-native playbook for leading Jules through issues, pull requests, reviews, CI, case studies, and controlled automation.
-
-This is not a prompt dump. It is a reusable starter kit for maintainers who want AI-assisted work to leave a clean engineering history.
-
-Repository: <https://github.com/hkimw-underground/vibe-coding-with-jules>
-
-Suggested public positioning:
-
-```text
-Repo name: jules-workflow-starter-kit
-Display title: AI Coding Workflow Starter Kit for Jules
-Tagline: Most AI coding demos show only the final code. This project shows the process.
-```
+**AI Coding Workflow Starter Kit for Jules** is a reusable GitHub-native playbook for maintainers who want AI-assisted work to leave a clean engineering history. It provides templates for leading Jules through issues, pull requests, reviews, CI, case studies, and controlled automation.
 
 ---
 
@@ -121,7 +109,7 @@ If another developer cannot understand the history later, the workflow failed.
 
 ### 1. Copy the Starter Kit
 
-Copy the parts that match your project:
+Copy the following folders and files directly into your own repository to get started:
 
 ```text
 AGENTS.md
@@ -178,7 +166,7 @@ This is a real hardware/software capstone case study. It shows how planning and 
 
 The maintainer owns architecture, hardware constraints, scope, review, and final merge decisions.
 
-### Case Study B: English-Only Open Source Project
+### [Case Study B: English-Only Open Source Project](./docs/case-studies/english-only-project.md)
 
 Status: planned.
 

--- a/docs/case-studies/english-only-project.md
+++ b/docs/case-studies/english-only-project.md
@@ -1,0 +1,5 @@
+# Case Study B: English-Only Open Source Project
+
+Status: planned.
+
+This will be a clean English-only project for a global audience. It should demonstrate small issues, focused Jules PRs, CI-first development, and readable review comments outside a school/capstone context.


### PR DESCRIPTION
Closes #23.

This PR prepares the repository for an "awesome-list" audience by polishing the READMEs and fixing a missing file reference. 

**Changes:**
- Removed internal planning notes ("Suggested public positioning") to make the README public-facing.
- Refined the intro paragraph to clarify the starter kit's value immediately.
- Updated the "Getting Started" copy to explicitly instruct users to copy the files to their own repository.
- Created `docs/case-studies/english-only-project.md` as a planned placeholder to match the repository tree reference.
- Updated `README.md` and `README.ko.md` to link the Case Study B heading to the new placeholder file.
- Ensured Korean and English README structures remained aligned.

**Validation Notes:**
- Confirmed relative links in the READMEs correctly point to the placeholder doc.
- Executed the YAML syntax validation from `.github/workflows/docs-and-templates.yml` locally.
- Executed the Markdown hygiene validation script locally.
- Executed the required files structure check locally.
- Docs CI should pass cleanly based on local runs.

*(Note: Assumed Case Study B placeholder text should follow the existing plan described in the README.)*

---
*PR created automatically by Jules for task [4577346986081916230](https://jules.google.com/task/4577346986081916230) started by @hkimw*