### PR TITLE
Add a copy-ready Quickstart guide

### DIFF
--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -117,6 +117,7 @@ jobs:
             ".github/PULL_REQUEST_TEMPLATE.md"
             ".github/ISSUE_TEMPLATE/jules_task.yml"
             ".github/ISSUE_TEMPLATE/workflow_experiment.yml"
+            "docs/quickstart.md"
             "docs/workflows/workflow-levels.md"
             "docs/experiments/no-human-only-jules-workflow.md"
             "docs/experiments/jules-alpha-evolve.md"

--- a/README.ko.md
+++ b/README.ko.md
@@ -45,6 +45,8 @@ graph LR
 
 ## Start Here
 
+**[Quickstart 가이드](./docs/quickstart.md)** (단계별 가이드)
+
 ### 1. Starter Kit 파일 복사하기
 
 자기 repository에 먼저 아래 파일들을 복사합니다.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Not:
 
 ## Start Here
 
+**[Quickstart Guide](./docs/quickstart.md)** (for a step-by-step onboarding)
+
 ### 1. Copy the Starter Kit Files
 
 Start with these files in your own repository:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -14,6 +14,7 @@ Copy these core files into your target repository:
 | `.github/workflows/docs-and-templates.yml` | Lightweight CI for Markdown and YAML hygiene. |
 
 **Optional but recommended:**
+
 - `prompts/`: Reusable prompts for handoffs and reports.
 - `examples/`: Reference issues and PR reviews.
 
@@ -21,7 +22,7 @@ Copy these core files into your target repository:
 
 Edit these fields to match your repository:
 
-- **`AGENTS.md`**: Update the "Repository Structure" and any specific coding standards or "Memories" relevant to your project.
+- **`AGENTS.md`**: Update the repository structure, project constraints, coding standards, and validation rules.
 - **`.github/ISSUE_TEMPLATE/jules_task.yml`**: Update the `labels` or `assignees` if you use specific ones for AI tasks.
 - **`.github/workflows/docs-and-templates.yml`**: Update the `required_paths` list if you choose not to copy certain optional files.
 
@@ -30,6 +31,7 @@ Edit these fields to match your repository:
 Start with a small, well-defined task. Avoid vague requests like "refactor the project."
 
 **Example Issue Body:**
+
 ```text
 [Jules Task] Add a basic unit test for the `utils/math.py` module.
 
@@ -42,18 +44,18 @@ Scope:
 
 Acceptance Criteria:
 - Tests pass locally.
-- 100% coverage for `utils/math.py`.
+- The new tests cover the targeted math utility functions.
 ```
 
 ## 4. Hand the Issue to Jules
 
 1. Open the issue in GitHub.
-2. In your Jules interface (or agentic environment), point Jules to the issue URL.
+2. In your Jules interface or agentic environment, point Jules to the issue URL.
 3. Jules should create a plan, execute the changes, and open a Pull Request.
 
 ## 5. Review the First PR
 
-Treat Jules like a junior engineer. Do not auto-merge.
+Review the PR as an agent-generated change. Do not auto-merge the first result.
 
 - **Check Scope**: Did Jules touch unrelated files?
 - **Verify Logic**: Does the code solve the problem described in the issue?
@@ -64,14 +66,14 @@ Treat Jules like a junior engineer. Do not auto-merge.
 
 1. Ensure all CI checks pass.
 2. Run the code locally if possible.
-3. Verify that documentation (like `AGENTS.md`) is updated if the project structure changed.
+3. Verify that documentation, such as `AGENTS.md`, is updated if the project structure changed.
 
-## What NOT to Automate (Yet)
+## What NOT to Automate Yet
 
 As you begin, keep these steps manual to maintain quality:
 
 - **Architecture Decisions**: Humans should define the high-level design.
-- **Final Merge**: Always require a human "LGTM" before merging to `main`.
+- **Final Merge**: Require human review before merging to `main`.
 - **Large Refactors**: Break big changes into small, Jules-sized issues.
 
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,79 @@
+# Quickstart Guide: Adopting the Jules Workflow
+
+This guide provides a copy-ready process for adopting the Jules AI coding workflow in your own repository.
+
+## 1. Copy the Starter Kit Files
+
+Copy these core files into your target repository:
+
+| Path | Description |
+| --- | --- |
+| `AGENTS.md` | Core instructions and project context for Jules. |
+| `.github/ISSUE_TEMPLATE/` | Scoped issue templates for tasks and experiments. |
+| `.github/PULL_REQUEST_TEMPLATE.md` | PR template with validation checklists. |
+| `.github/workflows/docs-and-templates.yml` | Lightweight CI for Markdown and YAML hygiene. |
+
+**Optional but recommended:**
+- `prompts/`: Reusable prompts for handoffs and reports.
+- `examples/`: Reference issues and PR reviews.
+
+## 2. Customize Your Configuration
+
+Edit these fields to match your repository:
+
+- **`AGENTS.md`**: Update the "Repository Structure" and any specific coding standards or "Memories" relevant to your project.
+- **`.github/ISSUE_TEMPLATE/jules_task.yml`**: Update the `labels` or `assignees` if you use specific ones for AI tasks.
+- **`.github/workflows/docs-and-templates.yml`**: Update the `required_paths` list if you choose not to copy certain optional files.
+
+## 3. Create Your First Jules-Ready Issue
+
+Start with a small, well-defined task. Avoid vague requests like "refactor the project."
+
+**Example Issue Body:**
+```text
+[Jules Task] Add a basic unit test for the `utils/math.py` module.
+
+Problem:
+The math utility functions are currently untested.
+
+Scope:
+- Create `tests/test_math.py`.
+- Add tests for `add`, `subtract`, and `multiply` functions.
+
+Acceptance Criteria:
+- Tests pass locally.
+- 100% coverage for `utils/math.py`.
+```
+
+## 4. Hand the Issue to Jules
+
+1. Open the issue in GitHub.
+2. In your Jules interface (or agentic environment), point Jules to the issue URL.
+3. Jules should create a plan, execute the changes, and open a Pull Request.
+
+## 5. Review the First PR
+
+Treat Jules like a junior engineer. Do not auto-merge.
+
+- **Check Scope**: Did Jules touch unrelated files?
+- **Verify Logic**: Does the code solve the problem described in the issue?
+- **Read History**: Are the commit messages and PR description clear?
+- **Request Changes**: If something is wrong, comment on the PR and ask Jules to fix it.
+
+## 6. Validate Before Merge
+
+1. Ensure all CI checks pass.
+2. Run the code locally if possible.
+3. Verify that documentation (like `AGENTS.md`) is updated if the project structure changed.
+
+## What NOT to Automate (Yet)
+
+As you begin, keep these steps manual to maintain quality:
+
+- **Architecture Decisions**: Humans should define the high-level design.
+- **Final Merge**: Always require a human "LGTM" before merging to `main`.
+- **Large Refactors**: Break big changes into small, Jules-sized issues.
+
+---
+
+*Note: Jules is an AI coding agent. Maintain a clean engineering history by following the Issue → Jules → PR → Review flow.*


### PR DESCRIPTION
Created a practical, concise Quickstart guide in `docs/quickstart.md` to help maintainers adopt the Jules workflow.
- Updated README.md and README.ko.md with prominent links to the guide.
- Added docs/quickstart.md to the required starter kit files in CI.
- Verified Markdown hygiene and structure checks locally.
- Followed Issue -> Jules -> PR -> Review workflow.

Fixes #33

---
*PR created automatically by Jules for task [2046023099043138732](https://jules.google.com/task/2046023099043138732) started by @hkimw*