### PR TITLE
Add copy-ready Quickstart guide

### DIFF
--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -117,6 +117,7 @@ jobs:
             ".github/PULL_REQUEST_TEMPLATE.md"
             ".github/ISSUE_TEMPLATE/jules_task.yml"
             ".github/ISSUE_TEMPLATE/workflow_experiment.yml"
+            "docs/quickstart.md"
             "docs/workflows/workflow-levels.md"
             "docs/experiments/no-human-only-jules-workflow.md"
             "docs/experiments/jules-alpha-evolve.md"

--- a/README.ko.md
+++ b/README.ko.md
@@ -45,6 +45,8 @@ graph LR
 
 ## Start Here
 
+[Quickstart 가이드 읽기](./docs/quickstart.md) (전체 워크스루).
+
 ### 1. Starter Kit 파일 복사하기
 
 자기 repository에 먼저 아래 파일들을 복사합니다.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Not:
 
 ## Start Here
 
+[Read the Quickstart guide](./docs/quickstart.md) for a complete walkthrough.
+
 ### 1. Copy the Starter Kit Files
 
 Start with these files in your own repository:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,71 @@
+# Quickstart Guide
+
+This guide shows you how to adopt the AI Coding Workflow Starter Kit for Jules in your own repository.
+
+## 1. Copy the Starter Kit Files
+
+Copy the following files and directories from this repository into your own:
+
+```text
+AGENTS.md
+.github/ISSUE_TEMPLATE/jules_task.yml
+.github/ISSUE_TEMPLATE/workflow_experiment.yml
+.github/PULL_REQUEST_TEMPLATE.md
+.github/workflows/docs-and-templates.yml
+```
+
+*(Optional but recommended)* You can also copy `prompts/` and `examples/` for reference.
+
+## 2. Customize the Files
+
+Edit the copied files to match your project:
+
+- Update `.github/PULL_REQUEST_TEMPLATE.md` to remove any validation steps that do not apply to your project.
+- Adjust `AGENTS.md` if your project has specific rules (e.g., "Always use TypeScript" or "Run `npm test` before submitting").
+- Modify the `.github/workflows/docs-and-templates.yml` file to fit your CI setup, or remove it if you prefer different validation.
+
+## 3. Create the First Jules-Ready Issue
+
+Create an issue in your repository. Be specific and scoped.
+
+**Good Issue Example:**
+```text
+Title: Add a Quickstart guide
+
+Body:
+Create `docs/quickstart.md`.
+It should include steps on how to copy starter kit files and create a Jules issue.
+Do not modify other existing documentation.
+```
+
+## 4. Hand the Issue to Jules
+
+Use the issue as the single source of truth. When assigning the task to Jules, simply provide the link to the issue or paste its contents. Jules will use the instructions in the issue and `AGENTS.md` to guide its work.
+
+## 5. Review the First Pull Request
+
+Jules will create a pull request linked to the issue. Before merging, verify:
+
+- Does the PR strictly solve the linked issue?
+- Is the scope controlled (no unrelated files changed)?
+- Are assumptions clearly stated in the PR description?
+- Are validation steps or tests included?
+
+## 6. Validate Docs and CI
+
+Ensure all automated checks pass:
+
+- Check that Markdown hygiene passes.
+- Confirm YAML files are structurally valid.
+- Verify that your project's primary CI pipeline passes.
+
+If CI fails, do not ignore it. Ask Jules to investigate and fix the root cause.
+
+## 7. What Not to Automate at the Beginning
+
+Start with the **Human-led Jules workflow** (Level 1).
+
+- **Do not auto-merge.** Always require human review.
+- **Do not skip CI.** Let CI gate every merge.
+- **Do not let Jules decide project architecture.** Maintainers own the direction.
+- **Do not present Jules as a human.** Keep the engineering history transparent.


### PR DESCRIPTION
This pull request addresses Issue #33 by creating a concise, copy-ready Quickstart guide for external maintainers adopting the starter kit. 

The guide reinforces the core workflow of `Issue → Jules → PR → CI → human review` and explicitly covers the following topics:
- What files to copy into a target repository.
- What fields maintainers should customize.
- How to create the first Jules-ready issue.
- How to hand the issue to Jules.
- How to review the first PR.
- How to validate docs/CI before merge.
- What not to automate at the beginning.

It also updates `README.md` and `README.ko.md` with links to the Quickstart and adds `docs/quickstart.md` to the required file list in `.github/workflows/docs-and-templates.yml`. 

**Validation notes:**
- **Links Check:** Verified that relative links added to READMEs are correct.
- **Markdown Hygiene:** Locally executed the project's Python Markdown checker ensuring no missing newlines, tab characters, or trailing spaces.
- **YAML Validation:** Verified that `docs-and-templates.yml` remains valid.
- **Starter Kit Checks:** Confirmed `docs/quickstart.md` is detected in the `required_paths` array.
- **Scope Verification:** No unrelated files, new automation, or experimental changes were added. Jules is correctly portrayed as an AI coding agent throughout the guide.

---
*PR created automatically by Jules for task [5181109586166586196](https://jules.google.com/task/5181109586166586196) started by @hkimw*