### PR TITLE
Add public project readiness checklist

### DIFF
--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -118,6 +118,7 @@ jobs:
             ".github/ISSUE_TEMPLATE/jules_task.yml"
             ".github/ISSUE_TEMPLATE/workflow_experiment.yml"
             "docs/quickstart.md"
+            "docs/meta/project-readiness.md"
             "docs/workflows/workflow-levels.md"
             "docs/experiments/no-human-only-jules-workflow.md"
             "docs/experiments/jules-alpha-evolve.md"

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,6 @@
 # AI Coding Workflow Starter Kit for Jules
 
-[English](./README.md) · [한국어](./README.ko.md) · [기여하기](./CONTRIBUTING.md) · [행동 강령](./CODE_OF_CONDUCT.md) · [보안](./SECURITY.md)
+[English](./README.md) · [한국어](./README.ko.md) · [프로젝트 준비 상태](./docs/meta/project-readiness.md) · [기여하기](./CONTRIBUTING.md) · [행동 강령](./CODE_OF_CONDUCT.md) · [보안](./SECURITY.md)
 
 > 대부분의 AI 코딩 데모는 완성된 코드만 보여줍니다.  
 > 이 프로젝트는 그 과정 자체를 보여줍니다.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Coding Workflow Starter Kit for Jules
 
-[English](./README.md) · [한국어](./README.ko.md) · [Contributing](./CONTRIBUTING.md) · [Code of Conduct](./CODE_OF_CONDUCT.md) · [Security](./SECURITY.md)
+[English](./README.md) · [한국어](./README.ko.md) · [Project Readiness](./docs/meta/project-readiness.md) · [Contributing](./CONTRIBUTING.md) · [Code of Conduct](./CODE_OF_CONDUCT.md) · [Security](./SECURITY.md)
 
 > Most AI coding demos show only the final code.  
 > This project shows the process.

--- a/docs/meta/project-readiness.md
+++ b/docs/meta/project-readiness.md
@@ -1,0 +1,39 @@
+# Project Readiness Checklist
+
+This document provides a concise overview of the repository's current state, quality standards, and planned improvements. It helps maintainers and readers understand the project's maturity and focus.
+
+## Project Summary
+A GitHub-native starter kit for leading the Jules AI coding agent through a structured engineering process of issues, pull requests, and human review.
+
+## What This Project Provides
+- **Scoped Issue Templates**: Pre-configured templates for Jules tasks and workflow experiments.
+- **PR Templates**: Standardized pull request format with validation checklists.
+- **Workflow Levels**: A framework for transitioning from human-led tasks to experimental automation.
+- **Reference Examples**: Real-world examples of issues and maintainer reviews.
+- **CI Validation**: Automated checks for Markdown hygiene, YAML syntax, and repository structure.
+- **Reusable Prompts**: Templates for handoffs and status reporting.
+
+## Why This is Not a Prompt Dump
+Unlike collections of "magic prompts," this project focuses on the **engineering process**. It treats AI as a contributor within a standard Git-based workflow. The goal is not just to generate code, but to create a readable, auditable, and maintainable engineering history where human maintainers retain control and accountability.
+
+## Quality Checklist
+- [x] **Core Documentation**: README and Quickstart guide are complete and up-to-date.
+- [x] **Bilingual Support**: Key documentation (README) is available in both English and Korean.
+- [x] **Structural Integrity**: A dedicated CI workflow ensures all required starter kit files are present.
+- [x] **Validation Gates**: Markdown and YAML syntax checks are enforced for all contributions.
+- [x] **Real-World Evidence**: Case studies demonstrate the workflow's application in practical scenarios.
+- [x] **Community Standards**: Includes Code of Conduct, Contributing guidelines, and Security policy.
+
+## Current Limitations
+- **Case Study B (English-Only)**: Currently planned and documented as a placeholder.
+- **Advanced Workflow Levels**: Levels 4-6 (e.g., daily agentic maintainer loop, no-human sandbox) are considered experimental and should not be used in production environments.
+- **Automation Scope**: The project intentionally avoids "auto-merge" or "auto-fix" automation to prioritize human oversight.
+
+## Key Resources
+- **[Quickstart Guide](../quickstart.md)**: Step-by-step onboarding for your first Jules task.
+- **[Reference Examples](../../examples/)**: Scoped issues and PR review examples.
+- **[Workflow Levels](../workflows/workflow-levels.md)**: Detailed breakdown of the six levels of AI integration.
+- **[Case Studies](../case-studies/)**: Analysis of the workflow applied to real-world projects.
+
+## Human-Led by Default
+The default and recommended workflow for this project remains **Level 1: Human-led Jules workflow**. A human maintainer is responsible for creating issues, reviewing every pull request, and making final merge decisions. Jules is a tool to assist, not a replacement for human engineering judgment.

--- a/docs/meta/project-readiness.md
+++ b/docs/meta/project-readiness.md
@@ -3,37 +3,44 @@
 This document provides a concise overview of the repository's current state, quality standards, and planned improvements. It helps maintainers and readers understand the project's maturity and focus.
 
 ## Project Summary
-A GitHub-native starter kit for leading the Jules AI coding agent through a structured engineering process of issues, pull requests, and human review.
+
+A GitHub-native starter kit for leading the Jules AI coding agent through a structured engineering process of issues, pull requests, CI, and human review.
 
 ## What This Project Provides
+
 - **Scoped Issue Templates**: Pre-configured templates for Jules tasks and workflow experiments.
 - **PR Templates**: Standardized pull request format with validation checklists.
-- **Workflow Levels**: A framework for transitioning from human-led tasks to experimental automation.
-- **Reference Examples**: Real-world examples of issues and maintainer reviews.
+- **Workflow Levels**: A framework for moving from human-led tasks to controlled automation experiments.
+- **Reference Examples**: Copyable examples of issues and maintainer reviews.
 - **CI Validation**: Automated checks for Markdown hygiene, YAML syntax, and repository structure.
 - **Reusable Prompts**: Templates for handoffs and status reporting.
 
-## Why This is Not a Prompt Dump
-Unlike collections of "magic prompts," this project focuses on the **engineering process**. It treats AI as a contributor within a standard Git-based workflow. The goal is not just to generate code, but to create a readable, auditable, and maintainable engineering history where human maintainers retain control and accountability.
+## Why This Is Not a Prompt Dump
+
+Unlike collections of "magic prompts," this project focuses on the **engineering process**. It treats Jules as an AI coding agent operating inside a standard GitHub workflow. The goal is not just to generate code, but to create a readable, auditable, and maintainable engineering history where human maintainers retain control and accountability.
 
 ## Quality Checklist
+
 - [x] **Core Documentation**: README and Quickstart guide are complete and up-to-date.
-- [x] **Bilingual Support**: Key documentation (README) is available in both English and Korean.
+- [x] **Bilingual Support**: Key README documentation is available in both English and Korean.
 - [x] **Structural Integrity**: A dedicated CI workflow ensures all required starter kit files are present.
-- [x] **Validation Gates**: Markdown and YAML syntax checks are enforced for all contributions.
-- [x] **Real-World Evidence**: Case studies demonstrate the workflow's application in practical scenarios.
-- [x] **Community Standards**: Includes Code of Conduct, Contributing guidelines, and Security policy.
+- [x] **Validation Gates**: Markdown and YAML syntax checks run for documentation and template changes.
+- [x] **Practical Evidence**: Case Study A documents the workflow in a real project, while Case Study B is tracked as planned.
+- [x] **Community Standards**: Includes Code of Conduct, contributing guidelines, license, and security policy.
 
 ## Current Limitations
+
 - **Case Study B (English-Only)**: Currently planned and documented as a placeholder.
-- **Advanced Workflow Levels**: Levels 4-6 (e.g., daily agentic maintainer loop, no-human sandbox) are considered experimental and should not be used in production environments.
-- **Automation Scope**: The project intentionally avoids "auto-merge" or "auto-fix" automation to prioritize human oversight.
+- **Advanced Workflow Levels**: Levels 4-6, such as daily maintainer reports and sandbox-only automation experiments, are intentionally documented as advanced or experimental.
+- **Automation Scope**: The default workflow does not recommend auto-merge or unattended project changes. Automation should remain gated by CI, branch protection, and human review unless it is explicitly isolated in a sandbox.
 
 ## Key Resources
+
 - **[Quickstart Guide](../quickstart.md)**: Step-by-step onboarding for your first Jules task.
 - **[Reference Examples](../../examples/)**: Scoped issues and PR review examples.
-- **[Workflow Levels](../workflows/workflow-levels.md)**: Detailed breakdown of the six levels of AI integration.
-- **[Case Studies](../case-studies/)**: Analysis of the workflow applied to real-world projects.
+- **[Workflow Levels](../workflows/workflow-levels.md)**: Detailed breakdown of the six workflow levels.
+- **[Case Studies](../case-studies/)**: Workflow examples and planned case study material.
 
 ## Human-Led by Default
-The default and recommended workflow for this project remains **Level 1: Human-led Jules workflow**. A human maintainer is responsible for creating issues, reviewing every pull request, and making final merge decisions. Jules is a tool to assist, not a replacement for human engineering judgment.
+
+The default and recommended workflow for this project remains **Level 1: Human-led Jules workflow**. A human maintainer is responsible for creating issues, reviewing every pull request, and making final merge decisions. Jules is an AI coding agent that assists the workflow, not a replacement for human engineering judgment.


### PR DESCRIPTION
This PR adds a public-facing project readiness checklist to help maintainers and readers understand the repository's quality bar and planned improvements.

### Changes:
- Created `docs/meta/project-readiness.md` containing:
    - One-line project summary.
    - List of project provisions (templates, examples, etc.).
    - Explanation of differentiation from prompt dumps.
    - Quality checklist.
    - Honest limitations.
    - Links to Quickstart, examples, workflow levels, and case studies.
    - Note that the default workflow remains human-led.
- Added relative links to the checklist in the header navigation of `README.md` and `README.ko.md`.
- Updated `.github/workflows/docs-and-templates.yml` to ensure the new file is tracked as a required starter kit component.

### Validation:
- Verified file creation and content.
- Verified README links are relative and correct.
- Ran local validation scripts for YAML syntax, Markdown hygiene, and starter kit structure. All checks passed.
- Adhered to all non-goals (no marketing hype, no new automation, no human contributor persona).

Fixes #36

---
*PR created automatically by Jules for task [11614596044506686341](https://jules.google.com/task/11614596044506686341) started by @hkimw*