### PR TITLE
Add public project readiness checklist

### DIFF
--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -118,6 +118,7 @@ jobs:
             ".github/ISSUE_TEMPLATE/jules_task.yml"
             ".github/ISSUE_TEMPLATE/workflow_experiment.yml"
             "docs/quickstart.md"
+            "docs/meta/project-readiness.md"
             "docs/workflows/workflow-levels.md"
             "docs/experiments/no-human-only-jules-workflow.md"
             "docs/experiments/jules-alpha-evolve.md"

--- a/README.ko.md
+++ b/README.ko.md
@@ -46,6 +46,7 @@ graph LR
 ## Start Here
 
 **[Quickstart 가이드](./docs/quickstart.md)** (단계별 가이드)
+**[Project Readiness](./docs/meta/project-readiness.md)** (품질 체크리스트 및 한계점)
 
 ### 1. Starter Kit 파일 복사하기
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Not:
 ## Start Here
 
 **[Quickstart Guide](./docs/quickstart.md)** (for a step-by-step onboarding)
+**[Project Readiness](./docs/meta/project-readiness.md)** (quality checklist and limitations)
 
 ### 1. Copy the Starter Kit Files
 

--- a/docs/meta/project-readiness.md
+++ b/docs/meta/project-readiness.md
@@ -1,0 +1,35 @@
+# Project Readiness
+
+**The AI Coding Workflow Starter Kit for Jules** is a GitHub-native starter kit for leading AI coding agents through normal engineering practices.
+
+## What this project provides
+
+This repository provides reusable templates, review checklists, CI constraints, and examples needed to establish a verifiable issue-to-merge workflow for AI agents.
+
+## How it differs from a prompt dump
+
+Rather than providing isolated instructions or large prompts for a single IDE interaction, this kit embeds guidance into standard GitHub mechanisms: issues, pull requests, automated CI checks, and human code reviews. It demonstrates the verifiable process of writing code, not just the final outcome.
+
+## Quality Checklist
+
+- [x] Scoped issue templates for agent tasks
+- [x] Pull request templates requiring linked issues and validation notes
+- [x] Lightweight CI checks for Markdown and YAML hygiene
+- [x] Reusable starter kit files (`AGENTS.md`, `.github/`)
+- [x] Examples of issues and PR reviews
+- [x] Case studies documenting real-world workflow usage
+
+## Current Limitations
+
+- Automation is deliberately constrained; human review remains mandatory for merging.
+- High-level architectural and design decisions are out of scope for the agent and must be provided by the human maintainer.
+- Advanced autonomous workflows (like evaluator-driven evolution) are strictly experimental and isolated from production branches.
+
+## Resources
+
+- [Quickstart Guide](../quickstart.md)
+- [Example Issues](../../examples/issues/README.md) and [PR Reviews](../../examples/pr-reviews/README.md)
+- [Workflow Levels](../workflows/workflow-levels.md)
+- [Case Studies](../case-studies/digital-logic-circuit.md)
+
+*Note: The default workflow in this starter kit remains human-led. Jules is an AI coding agent, and human maintainers are responsible for defining the scope, guiding direction, and approving the final work.*


### PR DESCRIPTION
This pull request adds a public project readiness checklist to explain why the project is ready for external readers and what still remains planned, as requested in Issue #36.

Validation notes:
- Created `docs/meta/project-readiness.md` checklist with summary, checklist, and limitations.
- Maintained non-promotional tone without marketing hype, and clearly delineated that Jules is an AI agent.
- Updated both `README.md` and `README.ko.md` with links to the new document.
- Passed all Markdown hygiene and CI structure checks required by `.github/workflows/docs-and-templates.yml`.

Closes #36.

---
*PR created automatically by Jules for task [17852958021116945326](https://jules.google.com/task/17852958021116945326) started by @hkimw*