### PR TITLE
Add one-Jules-task-at-a-time operations guide

### DIFF
--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -124,6 +124,7 @@ jobs:
             "docs/experiments/jules-alpha-evolve.md"
             "docs/case-studies/digital-logic-circuit.md"
             "docs/case-studies/english-only-project.md"
+            "docs/operations/one-jules-task-at-a-time.md"
             "prompts/issue-to-jules-task.md"
             "prompts/daily-maintainer-report.md"
             "examples/issues/README.md"

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,6 @@
 # AI Coding Workflow Starter Kit for Jules
 
-[English](./README.md) · [한국어](./README.ko.md) · [프로젝트 준비 상태](./docs/meta/project-readiness.md) · [기여하기](./CONTRIBUTING.md) · [행동 강령](./CODE_OF_CONDUCT.md) · [보안](./SECURITY.md)
+[English](./README.md) · [한국어](./README.ko.md) · [프로젝트 준비 상태](./docs/meta/project-readiness.md) · [운영 가이드](./docs/operations/one-jules-task-at-a-time.md) · [기여하기](./CONTRIBUTING.md) · [행동 강령](./CODE_OF_CONDUCT.md) · [보안](./SECURITY.md)
 
 > 대부분의 AI 코딩 데모는 완성된 코드만 보여줍니다.  
 > 이 프로젝트는 그 과정 자체를 보여줍니다.
@@ -135,9 +135,11 @@ Merge 전에 다음을 확인합니다.
 │   ├── experiments/
 │   │   ├── no-human-only-jules-workflow.md
 │   │   └── jules-alpha-evolve.md
-│   └── case-studies/
-│       ├── digital-logic-circuit.md
-│       └── english-only-project.md
+│   ├── case-studies/
+│   │   ├── digital-logic-circuit.md
+│   │   └── english-only-project.md
+│   └── operations/
+│       └── one-jules-task-at-a-time.md
 └── prompts/
     ├── issue-to-jules-task.md
     └── daily-maintainer-report.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Coding Workflow Starter Kit for Jules
 
-[English](./README.md) · [한국어](./README.ko.md) · [Project Readiness](./docs/meta/project-readiness.md) · [Contributing](./CONTRIBUTING.md) · [Code of Conduct](./CODE_OF_CONDUCT.md) · [Security](./SECURITY.md)
+[English](./README.md) · [한국어](./README.ko.md) · [Project Readiness](./docs/meta/project-readiness.md) · [Operations](./docs/operations/one-jules-task-at-a-time.md) · [Contributing](./CONTRIBUTING.md) · [Code of Conduct](./CODE_OF_CONDUCT.md) · [Security](./SECURITY.md)
 
 > Most AI coding demos show only the final code.  
 > This project shows the process.
@@ -135,9 +135,11 @@ The default workflow is Level 1. Levels 5 and 6 belong in sandboxes, not unprote
 │   ├── experiments/
 │   │   ├── no-human-only-jules-workflow.md
 │   │   └── jules-alpha-evolve.md
-│   └── case-studies/
-│       ├── digital-logic-circuit.md
-│       └── english-only-project.md
+│   ├── case-studies/
+│   │   ├── digital-logic-circuit.md
+│   │   └── english-only-project.md
+│   └── operations/
+│       └── one-jules-task-at-a-time.md
 └── prompts/
     ├── issue-to-jules-task.md
     └── daily-maintainer-report.md

--- a/docs/operations/one-jules-task-at-a-time.md
+++ b/docs/operations/one-jules-task-at-a-time.md
@@ -1,0 +1,65 @@
+# Operations Guide: One Jules Task at a Time
+
+Managing an AI coding agent requires sequencing to maintain a clean engineering history. While it is tempting to run multiple tasks in parallel, doing so can lead to stale Pull Requests (PRs) and merge conflicts, especially when tasks touch shared files.
+
+## Why One Task at a Time?
+
+Jules operates based on the current state of the repository. If you start Task B before Task A is merged:
+
+1. **Stale Context**: Task B may not "see" the changes from Task A.
+2. **Merge Conflicts**: Both tasks might modify the same lines in shared files (e.g., `README.md`, `AGENTS.md`, or CI configs).
+3. **Duplicate Work**: If Task A and Task B overlap in scope, Jules might implement the same logic twice in different ways.
+
+**Running tasks sequentially ensures that each task begins with the most up-to-date `main` branch.**
+
+## When Concurrent Tasks are Acceptable
+
+Concurrency is safe when tasks are strictly isolated:
+
+- Tasks touch different, unrelated directories (e.g., `docs/case-studies/` vs `examples/issues/`).
+- Tasks do not modify shared configuration files.
+- The repository has high modularity.
+
+## How Duplicate or Stale PRs Happen
+
+1. **Parallel Triggers**: A maintainer adds the `run-jules` label to two issues simultaneously.
+2. **Delayed Review**: Task A is finished but sits in PR. Task B is started from `main`, unaware of Task A's pending changes.
+3. **Overlapping Scope**: Two issues describe similar problems, leading Jules to create similar PRs.
+
+## How to Sequence Tasks Safely
+
+### 1. Sequence Issue Labels
+
+Do not label multiple issues with `run-jules` at once.
+
+- **Workflow**: Label Issue #1 → Wait for PR → Review/Merge PR → Update `main` → Label Issue #2.
+
+### 2. Keep Main Up to Date
+
+Before starting a new Jules task, ensure your remote `main` branch is up to date. Jules typically starts its task by checking out the latest `main`; if `main` is behind, Jules will work on stale code.
+
+### 3. Handle Stale PRs
+
+If a PR becomes stale due to a merge in `main`:
+
+- Ask Jules to rebase or update the branch.
+- If the PR is no longer needed, close it promptly to keep the PR list manageable.
+
+## Closing Duplicate PRs
+
+When Jules creates a duplicate or unnecessary PR, close it with a clear comment. This keeps the history clean and informs other maintainers.
+
+### Suggested Maintainer Comments
+
+**For a duplicate PR:**
+> Closing this as a duplicate of #PR_NUMBER. We are currently sequencing Jules tasks to avoid conflicts in shared files.
+
+**For a stale PR that is no longer needed:**
+> Closing this PR as the requirements have been addressed in #PR_NUMBER.
+
+**To Jules when requesting a restart:**
+> This PR has major conflicts with the updated `main`. I am closing this. Please start a new task based on the latest `main` branch from Issue #ISSUE_NUMBER.
+
+---
+
+*Note: Jules is an AI coding agent. Proper sequencing is a maintainer's responsibility to ensure a high-quality repository history.*


### PR DESCRIPTION
This PR adds a practical operations guide for sequencing Jules tasks, addressing issues discovered during dogfooding where concurrent tasks touched shared files.

### Changes
- Created `docs/operations/one-jules-task-at-a-time.md` covering sequencing why/how, handling duplicates, and suggested comments.
- Updated `README.md` and `README.ko.md` to include links to the new guide in the header and the repository structure visualization.
- Updated `.github/workflows/docs-and-templates.yml` to include the new guide in the `required_paths` list for the starter kit.

### Validation Notes
- **Operations guide created**: Verified content and formatting.
- **README links**: Relative links checked and are correct.
- **Markdown Hygiene**: Passed local python validation script (ends with newline, no tabs, correct trailing spaces).
- **YAML Syntax**: Passed local ruby validation script.
- **Starter Kit Structure**: New path added and verified via local bash script.
- **Docs CI**: Configured to pass with the new required file.

Linked Issue: [Jules Task] Add one-Jules-task-at-a-time operations guide

Fixes #39

---
*PR created automatically by Jules for task [14023328237663077243](https://jules.google.com/task/14023328237663077243) started by @hkimw*