### PR TITLE
docs: add one Jules task at a time operations guide

### DIFF
--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -118,6 +118,7 @@ jobs:
             ".github/ISSUE_TEMPLATE/jules_task.yml"
             ".github/ISSUE_TEMPLATE/workflow_experiment.yml"
             "docs/quickstart.md"
+            "docs/operations/one-jules-task-at-a-time.md"
             "docs/meta/project-readiness.md"
             "docs/workflows/workflow-levels.md"
             "docs/experiments/no-human-only-jules-workflow.md"

--- a/README.ko.md
+++ b/README.ko.md
@@ -45,8 +45,8 @@ graph LR
 
 ## Start Here
 
-- **[Quickstart 가이드](./docs/quickstart.md)** — 단계별 온보딩
-- **[운영 가이드](./docs/operations/one-jules-task-at-a-time.md)** — 안전한 태스크 순차 실행
+**[Quickstart 가이드](./docs/quickstart.md)** (단계별 가이드)
+**[운영 가이드](./docs/operations/one-jules-task-at-a-time.md)** (안전한 태스크 순차 실행 가이드)
 
 ### 1. Starter Kit 파일 복사하기
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -46,6 +46,7 @@ graph LR
 ## Start Here
 
 **[Quickstart 가이드](./docs/quickstart.md)** (단계별 가이드)
+**[운영 가이드](./docs/operations/one-jules-task-at-a-time.md)** (안전한 태스크 순차 실행 가이드)
 
 ### 1. Starter Kit 파일 복사하기
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -45,8 +45,8 @@ graph LR
 
 ## Start Here
 
-**[Quickstart 가이드](./docs/quickstart.md)** (단계별 가이드)
-**[운영 가이드](./docs/operations/one-jules-task-at-a-time.md)** (안전한 태스크 순차 실행 가이드)
+- **[Quickstart 가이드](./docs/quickstart.md)** — 단계별 온보딩
+- **[운영 가이드](./docs/operations/one-jules-task-at-a-time.md)** — 안전한 태스크 순차 실행
 
 ### 1. Starter Kit 파일 복사하기
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Not:
 
 ## Start Here
 
-**[Quickstart Guide](./docs/quickstart.md)** (for a step-by-step onboarding)
-**[Operations Guide](./docs/operations/one-jules-task-at-a-time.md)** (for sequencing tasks safely)
+- **[Quickstart Guide](./docs/quickstart.md)** — step-by-step onboarding
+- **[Operations Guide](./docs/operations/one-jules-task-at-a-time.md)** — sequencing tasks safely
 
 ### 1. Copy the Starter Kit Files
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Not:
 ## Start Here
 
 **[Quickstart Guide](./docs/quickstart.md)** (for a step-by-step onboarding)
+**[Operations Guide](./docs/operations/one-jules-task-at-a-time.md)** (for sequencing tasks safely)
 
 ### 1. Copy the Starter Kit Files
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Not:
 
 ## Start Here
 
-- **[Quickstart Guide](./docs/quickstart.md)** — step-by-step onboarding
-- **[Operations Guide](./docs/operations/one-jules-task-at-a-time.md)** — sequencing tasks safely
+**[Quickstart Guide](./docs/quickstart.md)** (for a step-by-step onboarding)
+**[Operations Guide](./docs/operations/one-jules-task-at-a-time.md)** (for sequencing tasks safely)
 
 ### 1. Copy the Starter Kit Files
 

--- a/docs/operations/one-jules-task-at-a-time.md
+++ b/docs/operations/one-jules-task-at-a-time.md
@@ -1,6 +1,6 @@
 # One Jules Task at a Time
 
-While dogfooding this starter kit, we learned a practical operational lesson: **running multiple Jules tasks concurrently on shared files can create duplicate or stale Pull Requests.**
+While dogfooding this starter kit, we learned a valuable operational lesson: **running multiple Jules tasks concurrently on shared files creates duplicate or stale Pull Requests.**
 
 This guide explains how to sequence Jules tasks safely, especially when tasks touch shared documentation or workflow files, and how to manage duplicate PRs when they occur.
 
@@ -8,48 +8,42 @@ This guide explains how to sequence Jules tasks safely, especially when tasks to
 
 Jules, as an AI coding agent, creates a branch from the current state of the repository, makes changes based on the issue, and opens a Pull Request.
 
-If you assign two tasks to Jules simultaneously, and both tasks require modifying a shared file such as `README.md` or `.github/workflows/docs-and-templates.yml`:
-
+If you assign two tasks to Jules simultaneously, and both tasks require modifying a shared file (e.g., `README.md` or `.github/workflows/docs-and-templates.yml`):
 1. **Branch 1** modifies the shared file.
 2. **Branch 2** modifies the same shared file based on the old state.
 3. Both branches open PRs.
-4. When PR 1 merges, PR 2 may face merge conflicts or need a fresh run from the updated `main` branch.
+4. When PR 1 merges, PR 2 may face merge conflicts or overwrite PR 1's changes if merged without a rebase.
 
-Running one Jules task at a time helps each new task branch from a `main` branch that includes all previous updates.
+Running one Jules task at a time ensures that each new task branches from a `main` branch that includes all previous updates.
 
 ## When Are Concurrent Tasks Acceptable?
 
-Concurrent Jules tasks are acceptable when the tasks modify **strictly disjoint** areas of the codebase. For example:
+Concurrent Jules tasks are safe when the tasks modify **strictly disjoint** areas of the codebase. For example:
+- Task A updates `docs/case-studies/digital-logic-circuit.md`
+- Task B adds a new feature in `src/utils/math.js`
 
-- Task A updates `docs/case-studies/digital-logic-circuit.md`.
-- Task B adds a new feature in `src/utils/math.js`.
-
-If you are confident the files will not overlap, you can run them simultaneously. If there is any risk of overlap, such as adding to a shared list of links in the README, queue the tasks.
+If you are confident the files will not overlap, you can run them simultaneously. If there is any risk of overlap (like adding to a shared list of links in the `README`), queue the tasks.
 
 ## Managing Issue Labels
 
 To sequence tasks effectively using labels like `run-jules`:
-
 1. Add `run-jules` to the first issue.
 2. Wait for Jules to open the PR.
-3. Review and merge the PR.
+3. Review, approve, and **merge the PR**.
 4. Once `main` is updated, add `run-jules` to the next issue.
 
-## Keeping `main` Current Between Tasks
+## How to Keep `main` Up to Date Between Tasks
 
-Always wait for a PR to merge before triggering the next Jules task that might touch the same files. If you trigger a task on an outdated `main` and a PR is opened:
-
-- Check whether the PR still applies cleanly.
-- If the PR has conflicts or duplicates already-merged work, close it with a clear maintainer comment.
-- Re-trigger the task from the updated `main` branch if the work is still needed.
+Always wait for a PR to merge before triggering the next Jules task that might touch the same files. If you do trigger a task on an outdated `main` and a PR is opened:
+- If the PR has conflicts, Jules cannot resolve them natively if the conflict requires complex human judgment.
+- You may need to close the PR and ask Jules to try again by re-triggering the task on the updated `main`.
 
 ## Handling Duplicate or Stale PRs
 
 If you accidentally trigger multiple tasks and get duplicate PRs attempting to solve similar problems or modifying the same shared file:
-
 1. Identify the PR that best solves the issue or is closest to mergeable.
 2. Review and merge that PR.
-3. Cleanly close the duplicate PRs.
+3. **Cleanly close the duplicate PRs.**
 
 ### Suggested Maintainer Comments for Closing Duplicates
 
@@ -57,6 +51,6 @@ When closing a stale or duplicate PR created by Jules, leave a clear comment for
 
 > **Closing as duplicate.** This change was addressed in #123. The underlying issue will be re-evaluated if needed.
 
-> **Closing as stale.** Another PR updated the shared `README.md` and this branch is now out of date. I will re-trigger the task from the updated `main` branch if the work is still needed.
+> **Closing as stale.** Another PR updated the shared `README.md` and this branch is now out of date. I will re-trigger the task from the updated `main` branch.
 
 By keeping a clean history and sequencing tasks logically, maintainers can guide Jules effectively without creating unnecessary conflict resolution work.

--- a/docs/operations/one-jules-task-at-a-time.md
+++ b/docs/operations/one-jules-task-at-a-time.md
@@ -1,0 +1,56 @@
+# One Jules Task at a Time
+
+While dogfooding this starter kit, we learned a valuable operational lesson: **running multiple Jules tasks concurrently on shared files creates duplicate or stale Pull Requests.**
+
+This guide explains how to sequence Jules tasks safely, especially when tasks touch shared documentation or workflow files, and how to manage duplicate PRs when they occur.
+
+## Why One Task at a Time?
+
+Jules, as an AI coding agent, creates a branch from the current state of the repository, makes changes based on the issue, and opens a Pull Request.
+
+If you assign two tasks to Jules simultaneously, and both tasks require modifying a shared file (e.g., `README.md` or `.github/workflows/docs-and-templates.yml`):
+1. **Branch 1** modifies the shared file.
+2. **Branch 2** modifies the same shared file based on the old state.
+3. Both branches open PRs.
+4. When PR 1 merges, PR 2 may face merge conflicts or overwrite PR 1's changes if merged without a rebase.
+
+Running one Jules task at a time ensures that each new task branches from a `main` branch that includes all previous updates.
+
+## When Are Concurrent Tasks Acceptable?
+
+Concurrent Jules tasks are safe when the tasks modify **strictly disjoint** areas of the codebase. For example:
+- Task A updates `docs/case-studies/digital-logic-circuit.md`
+- Task B adds a new feature in `src/utils/math.js`
+
+If you are confident the files will not overlap, you can run them simultaneously. If there is any risk of overlap (like adding to a shared list of links in the `README`), queue the tasks.
+
+## Managing Issue Labels
+
+To sequence tasks effectively using labels like `run-jules`:
+1. Add `run-jules` to the first issue.
+2. Wait for Jules to open the PR.
+3. Review, approve, and **merge the PR**.
+4. Once `main` is updated, add `run-jules` to the next issue.
+
+## How to Keep `main` Up to Date Between Tasks
+
+Always wait for a PR to merge before triggering the next Jules task that might touch the same files. If you do trigger a task on an outdated `main` and a PR is opened:
+- If the PR has conflicts, Jules cannot resolve them natively if the conflict requires complex human judgment.
+- You may need to close the PR and ask Jules to try again by re-triggering the task on the updated `main`.
+
+## Handling Duplicate or Stale PRs
+
+If you accidentally trigger multiple tasks and get duplicate PRs attempting to solve similar problems or modifying the same shared file:
+1. Identify the PR that best solves the issue or is closest to mergeable.
+2. Review and merge that PR.
+3. **Cleanly close the duplicate PRs.**
+
+### Suggested Maintainer Comments for Closing Duplicates
+
+When closing a stale or duplicate PR created by Jules, leave a clear comment for the engineering history:
+
+> **Closing as duplicate.** This change was addressed in #123. The underlying issue will be re-evaluated if needed.
+
+> **Closing as stale.** Another PR updated the shared `README.md` and this branch is now out of date. I will re-trigger the task from the updated `main` branch.
+
+By keeping a clean history and sequencing tasks logically, maintainers can guide Jules effectively without creating unnecessary conflict resolution work.

--- a/docs/operations/one-jules-task-at-a-time.md
+++ b/docs/operations/one-jules-task-at-a-time.md
@@ -1,6 +1,6 @@
 # One Jules Task at a Time
 
-While dogfooding this starter kit, we learned a valuable operational lesson: **running multiple Jules tasks concurrently on shared files creates duplicate or stale Pull Requests.**
+While dogfooding this starter kit, we learned a practical operational lesson: **running multiple Jules tasks concurrently on shared files can create duplicate or stale Pull Requests.**
 
 This guide explains how to sequence Jules tasks safely, especially when tasks touch shared documentation or workflow files, and how to manage duplicate PRs when they occur.
 
@@ -8,42 +8,48 @@ This guide explains how to sequence Jules tasks safely, especially when tasks to
 
 Jules, as an AI coding agent, creates a branch from the current state of the repository, makes changes based on the issue, and opens a Pull Request.
 
-If you assign two tasks to Jules simultaneously, and both tasks require modifying a shared file (e.g., `README.md` or `.github/workflows/docs-and-templates.yml`):
+If you assign two tasks to Jules simultaneously, and both tasks require modifying a shared file such as `README.md` or `.github/workflows/docs-and-templates.yml`:
+
 1. **Branch 1** modifies the shared file.
 2. **Branch 2** modifies the same shared file based on the old state.
 3. Both branches open PRs.
-4. When PR 1 merges, PR 2 may face merge conflicts or overwrite PR 1's changes if merged without a rebase.
+4. When PR 1 merges, PR 2 may face merge conflicts or need a fresh run from the updated `main` branch.
 
-Running one Jules task at a time ensures that each new task branches from a `main` branch that includes all previous updates.
+Running one Jules task at a time helps each new task branch from a `main` branch that includes all previous updates.
 
 ## When Are Concurrent Tasks Acceptable?
 
-Concurrent Jules tasks are safe when the tasks modify **strictly disjoint** areas of the codebase. For example:
-- Task A updates `docs/case-studies/digital-logic-circuit.md`
-- Task B adds a new feature in `src/utils/math.js`
+Concurrent Jules tasks are acceptable when the tasks modify **strictly disjoint** areas of the codebase. For example:
 
-If you are confident the files will not overlap, you can run them simultaneously. If there is any risk of overlap (like adding to a shared list of links in the `README`), queue the tasks.
+- Task A updates `docs/case-studies/digital-logic-circuit.md`.
+- Task B adds a new feature in `src/utils/math.js`.
+
+If you are confident the files will not overlap, you can run them simultaneously. If there is any risk of overlap, such as adding to a shared list of links in the README, queue the tasks.
 
 ## Managing Issue Labels
 
 To sequence tasks effectively using labels like `run-jules`:
+
 1. Add `run-jules` to the first issue.
 2. Wait for Jules to open the PR.
-3. Review, approve, and **merge the PR**.
+3. Review and merge the PR.
 4. Once `main` is updated, add `run-jules` to the next issue.
 
-## How to Keep `main` Up to Date Between Tasks
+## Keeping `main` Current Between Tasks
 
-Always wait for a PR to merge before triggering the next Jules task that might touch the same files. If you do trigger a task on an outdated `main` and a PR is opened:
-- If the PR has conflicts, Jules cannot resolve them natively if the conflict requires complex human judgment.
-- You may need to close the PR and ask Jules to try again by re-triggering the task on the updated `main`.
+Always wait for a PR to merge before triggering the next Jules task that might touch the same files. If you trigger a task on an outdated `main` and a PR is opened:
+
+- Check whether the PR still applies cleanly.
+- If the PR has conflicts or duplicates already-merged work, close it with a clear maintainer comment.
+- Re-trigger the task from the updated `main` branch if the work is still needed.
 
 ## Handling Duplicate or Stale PRs
 
 If you accidentally trigger multiple tasks and get duplicate PRs attempting to solve similar problems or modifying the same shared file:
+
 1. Identify the PR that best solves the issue or is closest to mergeable.
 2. Review and merge that PR.
-3. **Cleanly close the duplicate PRs.**
+3. Cleanly close the duplicate PRs.
 
 ### Suggested Maintainer Comments for Closing Duplicates
 
@@ -51,6 +57,6 @@ When closing a stale or duplicate PR created by Jules, leave a clear comment for
 
 > **Closing as duplicate.** This change was addressed in #123. The underlying issue will be re-evaluated if needed.
 
-> **Closing as stale.** Another PR updated the shared `README.md` and this branch is now out of date. I will re-trigger the task from the updated `main` branch.
+> **Closing as stale.** Another PR updated the shared `README.md` and this branch is now out of date. I will re-trigger the task from the updated `main` branch if the work is still needed.
 
 By keeping a clean history and sequencing tasks logically, maintainers can guide Jules effectively without creating unnecessary conflict resolution work.


### PR DESCRIPTION
This PR implements the operations guide for sequencing Jules tasks, addressing issue #39. 

Scope of changes:
- Created `docs/operations/one-jules-task-at-a-time.md` explaining why running one Jules task at a time is safer, when concurrent tasks are acceptable, how to manage labels, and how to handle duplicate PRs.
- Updated `README.md` and `README.ko.md` with a relative link to the new operations guide to improve discoverability.
- Updated `.github/workflows/docs-and-templates.yml` to require the new operations guide in the starter kit file list.

Validation notes:
- The new operations guide was added.
- The README links are relative and correct.
- Markdown hygiene passes (no trailing space errors after corrections).
- Docs CI checks (YAML syntax and Starter kit structure) pass.
- Jules is strictly framed as an AI coding agent, and the language is kept non-promotional and practical.

---
*PR created automatically by Jules for task [1675627275139930977](https://jules.google.com/task/1675627275139930977) started by @hkimw*