### PR TITLE
Sync README repository structure

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -45,9 +45,9 @@ graph LR
 
 ## Start Here
 
-**[Quickstart 가이드](./docs/quickstart.md)** (단계별 가이드)
-**[운영 가이드](./docs/operations/one-jules-task-at-a-time.md)** (안전한 태스크 순차 실행 가이드)
-**[브랜치 보호 가이드](./docs/operations/branch-protection-and-ci-gates.md)** (CI 게이트와 main 보호를 위해)
+- **[Quickstart 가이드](./docs/quickstart.md)** — 단계별 온보딩
+- **[운영 가이드](./docs/operations/one-jules-task-at-a-time.md)** — 안전한 태스크 순차 실행
+- **[브랜치 보호 가이드](./docs/operations/branch-protection-and-ci-gates.md)** — CI 게이트와 `main` 보호
 
 ### 1. Starter Kit 파일 복사하기
 
@@ -132,6 +132,12 @@ Merge 전에 다음을 확인합니다.
 │   ├── issues/
 │   └── pr-reviews/
 ├── docs/
+│   ├── quickstart.md
+│   ├── meta/
+│   │   └── project-readiness.md
+│   ├── operations/
+│   │   ├── one-jules-task-at-a-time.md
+│   │   └── branch-protection-and-ci-gates.md
 │   ├── workflows/
 │   │   └── workflow-levels.md
 │   ├── experiments/

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Not:
 
 ## Start Here
 
-**[Quickstart Guide](./docs/quickstart.md)** (for a step-by-step onboarding)
-**[Operations Guide](./docs/operations/one-jules-task-at-a-time.md)** (for sequencing tasks safely)
-**[Branch Protection Guide](./docs/operations/branch-protection-and-ci-gates.md)** (for CI gates and protecting main)
+- **[Quickstart Guide](./docs/quickstart.md)** — step-by-step onboarding
+- **[Operations Guide](./docs/operations/one-jules-task-at-a-time.md)** — sequencing tasks safely
+- **[Branch Protection Guide](./docs/operations/branch-protection-and-ci-gates.md)** — CI gates and protecting `main`
 
 ### 1. Copy the Starter Kit Files
 
@@ -132,6 +132,12 @@ The default workflow is Level 1. Levels 5 and 6 belong in sandboxes, not unprote
 │   ├── issues/
 │   └── pr-reviews/
 ├── docs/
+│   ├── quickstart.md
+│   ├── meta/
+│   │   └── project-readiness.md
+│   ├── operations/
+│   │   ├── one-jules-task-at-a-time.md
+│   │   └── branch-protection-and-ci-gates.md
 │   ├── workflows/
 │   │   └── workflow-levels.md
 │   ├── experiments/


### PR DESCRIPTION
## Summary

Synchronizes the repository structure section in both READMEs with the current docs layout.

## Changes

- Add `docs/quickstart.md` to the README tree.
- Add `docs/meta/project-readiness.md` to the README tree.
- Add `docs/operations/` guides to the README tree.
- Keep README.md and README.ko.md aligned.
- Normalize the Start Here guide links as bullets.

## Validation

- [x] README links are relative.
- [x] English and Korean README structure sections are aligned.
- [x] Changes are limited to README structure/link polish.
- [ ] Docs CI passes.

## Scope Control

- [x] No workflow behavior changed.
- [x] No case study content changed.
- [x] No community standard files changed.
