### PR TITLE
Expand Case Study B into a concrete project brief

### DIFF
--- a/docs/case-studies/english-only-project.md
+++ b/docs/case-studies/english-only-project.md
@@ -6,7 +6,7 @@ This case study will document a clean English-only open-source project using the
 
 ## Purpose
 
-Case Study B exists to show that the workflow is reusable outside a school or capstone context.
+Case Study B exists to show that the workflow is reusable outside a school or capstone context. It will demonstrate how a human maintainer leads Jules (an AI coding agent) through standard GitHub engineering practices for a globally accessible open-source project.
 
 It should demonstrate:
 
@@ -16,37 +16,68 @@ It should demonstrate:
 - readable human review comments
 - clear separation between AI agent work and maintainer ownership
 
-## Selection Criteria
+## Recommended Project Direction
 
-A good Case Study B candidate should:
+**Primary Option: Markdown link checker mini CLI**
 
-- be understandable to a global open-source audience
-- have a small but real implementation surface
-- support automated tests or lightweight CI
-- allow issues to be completed through small PRs
-- avoid private, school-specific, or organization-specific context
-- keep Jules framed as an AI coding agent, not a human contributor
+A small English-only developer tool or documentation-focused utility is the best fit because it is easy for global readers to understand, test, and review. A Markdown link checker mini CLI provides a real, testable implementation surface without domain-specific complexity.
 
-## Expected Workflow
+## Project Constraints
+
+To ensure a clear, readable case study, the project must:
+
+- Avoid private, school-specific, or organization-specific context.
+- Not be used to demonstrate fully autonomous development.
+- Not mix unrelated goals such as branding, large architecture rewrites, or product strategy.
+- Maintain Jules's identity strictly as an AI coding agent, not a human contributor.
+
+## Suggested Repository Name Options
+
+- `md-link-checker-cli`
+- `markdown-link-validator`
+- `simple-md-link-checker`
+
+## First 5 Starter Issues for Jules
+
+1. **Setup project scaffolding and CI:** Initialize the project structure and add a basic GitHub Actions workflow for linting and testing.
+2. **Implement CLI argument parsing:** Add the ability to accept a file path or directory as input.
+3. **Implement Markdown parsing:** Extract all URLs from the provided Markdown files.
+4. **Implement HTTP link validation:** Check the extracted URLs to see if they return a 200 OK status.
+5. **Format output results:** Display the results of the link checks clearly in the console (e.g., success, broken links).
+
+## Expected Workflow Sequence
+
+The project will strictly follow this PR sequence for every task:
 
 ```text
 Issue → Jules task → Pull request → CI → Human review → Merge
 ```
 
-## Non-goals
+Each PR must be small, focused, and directly linked to a single issue. Unrelated refactors are prohibited.
 
-This case study should not be used to demonstrate fully autonomous development.
+## CI Requirements
 
-It should not mix unrelated goals such as branding, large architecture rewrites, or product strategy.
+The project must implement CI gates to enforce quality before human review:
 
-## Maintainer Notes
+- **Linting:** Code formatting and style checks.
+- **Tests:** Automated unit tests for core logic (e.g., parsing, validation).
+- **Build/Type Check:** If applicable, ensure the project builds or type-checks successfully.
 
-When this case study is selected, replace this placeholder with:
+CI must pass before the maintainer reviews the PR.
 
-- repository link
-- project summary
-- selected issues
-- representative Jules PRs
-- review examples
-- CI results
-- lessons learned
+## Review Examples to Capture
+
+During the project, maintainers should save examples of:
+
+- A PR where the maintainer requested changes due to scope creep.
+- A PR where Jules added tests to fix a CI failure.
+- A PR approved and merged cleanly after addressing human feedback.
+
+## Completion Criteria
+
+The planned brief can be replaced with the real case study when the following criteria are met:
+
+- The repository is created and public.
+- The 5 starter issues are completed via the Jules workflow.
+- PRs clearly demonstrate the human-led AI coding process.
+- Examples of issues, PR descriptions, CI runs, and human reviews are captured and documented.


### PR DESCRIPTION
This PR expands the Case Study B placeholder into a concrete project brief. It does not complete the case study itself (the status remains planned) but provides the necessary structure and requirements for a maintainer to run it later.

Changes include:
- Recommending a "Markdown link checker mini CLI" as the primary option.
- Adding constraints to avoid school/organization contexts and maintain Jules's identity strictly as an AI agent.
- Suggesting repository name options.
- Providing the first 5 starter issues suitable for Jules tasks.
- Documenting the expected workflow sequence, CI requirements, and examples of reviews to capture.
- Adding completion criteria for when the case study can be considered fully executed.

Validation:
- Case Study B still does not claim completion (status is `planned`).
- Markdown hygiene passes (no tabs, ends with a newline, no trailing whitespace errors).
- Docs CI inline script checks ran successfully locally.
- Jules is referred to as an AI coding agent.

---
*PR created automatically by Jules for task [4738554399184346568](https://jules.google.com/task/4738554399184346568) started by @hkimw*