### PR TITLE
Expand Case Study B into a concrete project brief

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -167,9 +167,9 @@ Architecture, hardware constraints, scope, review, final merge decision은 maint
 
 ### [Case Study B: English-Only Open Source Project](./docs/case-studies/english-only-project.md)
 
-Status: planned.
+Status: planned (`md-link-linter`).
 
-글로벌 독자를 위한 예정된 순수 영어 case study입니다. 학교/capstone 맥락 밖에서도 small issues, focused Jules PRs, CI-first development, readable review comments가 재사용 가능하다는 것을 보여주는 목적입니다.
+글로벌 독자를 위한 예정된 순수 영어 case study입니다. 학교/capstone 맥락 밖에서도 minimalist Markdown link checker 제작 과정을 통해 small issues, focused Jules PRs, CI-first development, readable review comments가 재사용 가능하다는 것을 보여주는 목적입니다.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -167,9 +167,9 @@ The maintainer owns architecture, hardware constraints, scope, review, and final
 
 ### [Case Study B: English-Only Open Source Project](./docs/case-studies/english-only-project.md)
 
-Status: planned.
+Status: planned (`md-link-linter`).
 
-A planned English-only case study for a global audience. It will demonstrate the same workflow outside a school/capstone context: small issues, focused Jules PRs, CI-first development, and readable review comments.
+A planned English-only case study for a global audience. It will demonstrate the same workflow outside a school/capstone context by building a minimalist Markdown link checker: small issues, focused Jules PRs, CI-first development, and readable review comments.
 
 ---
 

--- a/docs/case-studies/english-only-project.md
+++ b/docs/case-studies/english-only-project.md
@@ -6,38 +6,71 @@ This case study will document a clean English-only open-source project using the
 
 ## Purpose
 
-Case Study B exists to show that the workflow is reusable outside a school or capstone context.
+Case Study B exists to show that the workflow is reusable outside a school or capstone context, specifically for a global audience using English as the primary language for code, documentation, and collaboration.
 
 It should demonstrate:
 
-- small GitHub Issues
-- focused Jules pull requests
+- Small GitHub Issues
+- Focused Jules pull requests
 - CI-first development
-- readable human review comments
-- clear separation between AI agent work and maintainer ownership
+- Readable human review comments
+- Clear separation between AI agent work and maintainer ownership
 
-## Selection Criteria
+## Recommended Project: `md-link-linter`
 
-A good Case Study B candidate should:
+To demonstrate the workflow, Case Study B recommends building a minimalist Markdown link checker CLI tool.
 
-- be understandable to a global open-source audience
-- have a small but real implementation surface
-- support automated tests or lightweight CI
-- allow issues to be completed through small PRs
-- avoid private, school-specific, or organization-specific context
-- keep Jules framed as an AI coding agent, not a human contributor
+**Description:** A command-line tool that scans Markdown files for broken internal and external links.
 
-## Expected Workflow
+### Project Constraints
 
-```text
-Issue → Jules task → Pull request → CI → Human review → Merge
-```
+- **English-Only:** All code, comments, issues, and documentation must be in English.
+- **Small Surface:** Focus on core functionality (parsing links, checking status) rather than complex edge cases.
+- **Testability:** Must support automated unit tests for link parsing and status checking.
+- **Jules-Friendly:** Issues should be small enough to be completed in single-digit file changes.
 
-## Non-goals
+### Repository Name Options
 
-This case study should not be used to demonstrate fully autonomous development.
+- `md-link-linter`
+- `link-check-mini`
+- `jules-linter-demo`
 
-It should not mix unrelated goals such as branding, large architecture rewrites, or product strategy.
+## First 5 Starter Issues for Jules
+
+1. **Initialize CLI project structure**: Set up a basic project structure with a CLI entry point that accepts a file path and prints "Checking [file]...".
+2. **Implement Markdown link extractor**: Write a parser to extract all Markdown-style links `[text](url)` from a given file.
+3. **Add internal link validation**: Implement a check to verify that internal relative links (e.g., `./docs/setup.md`) point to existing files on disk.
+4. **Add external link validation**: Use a lightweight HTTP library to check if external URLs return a successful status code.
+5. **Implement summary reporter**: Add a final report to the CLI output showing the total number of links checked, number of broken links, and a list of failed URLs.
+
+## Expected PR Sequence
+
+1. **PR 1 (Scaffolding)**: Basic project structure, dependency management, and "hello world" CLI.
+2. **PR 2 (Link Extraction)**: Core parsing logic with unit tests.
+3. **PR 3 (Local Check)**: File system existence checks for relative links.
+4. **PR 4 (Remote Check)**: Network requests for external links with timeout handling.
+5. **PR 5 (UX/Reporting)**: Polished console output and error summary.
+
+## CI Requirements
+
+- **Linting**: Standard linting rules for the chosen language.
+- **Tests**: Automated test suite running on every PR via GitHub Actions.
+- **Hygiene**: Markdown hygiene checks for the project's own documentation.
+
+## Review Examples to Capture
+
+- **Approval**: A review where the maintainer confirms the link parsing correctly handles edge case formats.
+- **Change Request**: A review where the maintainer asks Jules to add a timeout to the external link check.
+- **Refinement**: A review where the maintainer suggests a better error message for missing files.
+
+## Completion Criteria
+
+This planned brief can be replaced by the real case study once the following are met:
+
+1. The separate repository is created and public.
+2. At least 5 Jules-driven PRs have been merged following the workflow.
+3. The repo includes a clear README and CI status.
+4. Representative PRs and reviews are linked in the final case study document.
 
 ## Maintainer Notes
 


### PR DESCRIPTION
This PR expands the Case Study B placeholder into a concrete project brief for building `md-link-linter`, a minimalist Markdown link checker.

The brief includes:
- Clear "planned" status.
- Purpose of the English-only case study.
- Recommended project: `md-link-linter`.
- Project constraints and name options.
- 5 specific starter issues suitable for Jules.
- Expected PR sequence and CI requirements.
- Review examples and completion criteria.

Both `README.md` and `README.ko.md` have been updated for consistency. Local Docs CI validation (YAML syntax, Markdown hygiene, and structure) passed.

Validation notes:
- Case Study B still marks status as planned.
- Markdown hygiene (newline at end, no tabs, no trailing spaces) verified.
- All links are relative and correct.
- Jules is framed as an AI coding agent.

Fixes #52

---
*PR created automatically by Jules for task [17865901939860372083](https://jules.google.com/task/17865901939860372083) started by @hkimw*