### PR TITLE
Refine Case Study B project brief

### DIFF
--- a/docs/case-studies/english-only-project.md
+++ b/docs/case-studies/english-only-project.md
@@ -11,7 +11,7 @@ Case Study B exists to show that the workflow is reusable outside a school or ca
 It should demonstrate:
 
 - Small GitHub Issues
-- Focused Jules pull requests
+- Focused Jules-assisted pull requests
 - CI-first development
 - Readable human review comments
 - Clear separation between AI agent work and maintainer ownership
@@ -20,66 +20,72 @@ It should demonstrate:
 
 To demonstrate the workflow, Case Study B recommends building a minimalist Markdown link checker CLI tool.
 
-**Description:** A command-line tool that scans Markdown files for broken internal and external links.
+**Description:** A command-line tool that scans Markdown files and reports internal or external links that need attention.
 
 ### Project Constraints
 
-- **English-Only:** All code, comments, issues, and documentation must be in English.
-- **Small Surface:** Focus on core functionality (parsing links, checking status) rather than complex edge cases.
-- **Testability:** Must support automated unit tests for link parsing and status checking.
-- **Jules-Friendly:** Issues should be small enough to be completed in single-digit file changes.
+- **English-only:** All code, comments, issues, and documentation should be in English.
+- **Small surface:** Focus on core functionality, such as parsing links and reporting status, rather than complex edge cases.
+- **Testability:** The project should support automated unit tests for link parsing and reporting behavior.
+- **Issue-sized tasks:** Issues should be small enough to be completed in focused PRs with limited file changes.
 
 ### Repository Name Options
 
 - `md-link-linter`
 - `link-check-mini`
-- `jules-linter-demo`
+- `simple-md-link-checker`
 
 ## First 5 Starter Issues for Jules
 
-1. **Initialize CLI project structure**: Set up a basic project structure with a CLI entry point that accepts a file path and prints "Checking [file]...".
-2. **Implement Markdown link extractor**: Write a parser to extract all Markdown-style links `[text](url)` from a given file.
-3. **Add internal link validation**: Implement a check to verify that internal relative links (e.g., `./docs/setup.md`) point to existing files on disk.
-4. **Add external link validation**: Use a lightweight HTTP library to check if external URLs return a successful status code.
-5. **Implement summary reporter**: Add a final report to the CLI output showing the total number of links checked, number of broken links, and a list of failed URLs.
+1. **Initialize CLI project structure:** Set up a basic project structure with a CLI entry point that accepts a file path and prints `Checking [file]...`.
+2. **Implement Markdown link extractor:** Write a parser to extract Markdown-style links such as `[text](url)` from a given file.
+3. **Add internal link validation:** Implement a check to verify that internal relative links, such as `./docs/setup.md`, point to existing files on disk.
+4. **Add external link reporting:** Add basic status reporting for external links with a clear timeout policy.
+5. **Implement summary reporter:** Add a final report to the CLI output showing the total number of links checked and the items that need attention.
 
 ## Expected PR Sequence
 
-1. **PR 1 (Scaffolding)**: Basic project structure, dependency management, and "hello world" CLI.
-2. **PR 2 (Link Extraction)**: Core parsing logic with unit tests.
-3. **PR 3 (Local Check)**: File system existence checks for relative links.
-4. **PR 4 (Remote Check)**: Network requests for external links with timeout handling.
-5. **PR 5 (UX/Reporting)**: Polished console output and error summary.
+1. **PR 1: Scaffolding** — basic project structure, dependency management, and a minimal CLI.
+2. **PR 2: Link extraction** — core parsing logic with unit tests.
+3. **PR 3: Local checks** — file system existence checks for relative links.
+4. **PR 4: External link reporting** — external link status reporting with timeout handling.
+5. **PR 5: Reporting** — clear console output and summary behavior.
+
+Each PR should follow the same sequence:
+
+```text
+Issue → Jules task → Pull request → CI → Human review → Merge
+```
 
 ## CI Requirements
 
-- **Linting**: Standard linting rules for the chosen language.
-- **Tests**: Automated test suite running on every PR via GitHub Actions.
-- **Hygiene**: Markdown hygiene checks for the project's own documentation.
+- **Linting:** Standard linting rules for the chosen language.
+- **Tests:** Automated test suite running on every PR via GitHub Actions.
+- **Documentation hygiene:** Markdown checks for the project's own documentation.
 
 ## Review Examples to Capture
 
-- **Approval**: A review where the maintainer confirms the link parsing correctly handles edge case formats.
-- **Change Request**: A review where the maintainer asks Jules to add a timeout to the external link check.
-- **Refinement**: A review where the maintainer suggests a better error message for missing files.
+- **Approval:** A review where the maintainer confirms the link parser handles the intended Markdown formats.
+- **Change request:** A review where the maintainer asks Jules to add a timeout to external link reporting.
+- **Refinement:** A review where the maintainer suggests a clearer error message for missing files.
 
 ## Completion Criteria
 
 This planned brief can be replaced by the real case study once the following are met:
 
 1. The separate repository is created and public.
-2. At least 5 Jules-driven PRs have been merged following the workflow.
-3. The repo includes a clear README and CI status.
-4. Representative PRs and reviews are linked in the final case study document.
+2. At least 5 Jules-assisted PRs have been merged following the workflow.
+3. The repository includes a clear README and CI status.
+4. Representative issues, PR descriptions, CI runs, and human reviews are linked in the final case study document.
 
 ## Maintainer Notes
 
-When this case study is selected, replace this placeholder with:
+When this case study is selected, replace this planned brief with:
 
 - repository link
 - project summary
 - selected issues
-- representative Jules PRs
+- representative Jules-assisted PRs
 - review examples
 - CI results
 - lessons learned


### PR DESCRIPTION
## Summary

Follow-up cleanup after #54.

Refines the merged Case Study B project brief while keeping the status clearly planned.

## Changes

- Replace the `jules-linter-demo` repository name option with a more neutral option.
- Use `Jules-assisted` wording instead of stronger automation wording.
- Make task constraints more maintainer-oriented and less tool-branded.
- Keep the document scoped to the planned Case Study B brief.

## Validation

- [x] Case Study B still does not claim completion.
- [x] Jules remains framed as an AI coding agent.
- [x] Links remain relative.
- [x] Changes are limited to Case Study B wording.
- [ ] Docs CI passes.
