### PR TITLE
Add Label and Triage Operations Guide

### DIFF
--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -120,6 +120,7 @@ jobs:
             "docs/quickstart.md"
             "docs/operations/one-jules-task-at-a-time.md"
             "docs/operations/branch-protection-and-ci-gates.md"
+            "docs/operations/labels-and-triage.md"
             "docs/meta/project-readiness.md"
             "docs/meta/release-checklist.md"
             "docs/meta/documentation-audit.md"

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,6 +47,7 @@ graph LR
 
 - **[Quickstart 가이드](./docs/quickstart.md)** — 단계별 온보딩
 - **[운영 가이드](./docs/operations/one-jules-task-at-a-time.md)** — 안전한 태스크 순차 실행
+- **[레이블 및 트리아지 가이드](./docs/operations/labels-and-triage.md)** — 레이블을 이용한 작업 정리
 - **[브랜치 보호 가이드](./docs/operations/branch-protection-and-ci-gates.md)** — CI 게이트와 `main` 보호
 
 ### 1. Starter Kit 파일 복사하기
@@ -139,7 +140,8 @@ Merge 전에 다음을 확인합니다.
 │   │   └── documentation-audit.md
 │   ├── operations/
 │   │   ├── one-jules-task-at-a-time.md
-│   │   └── branch-protection-and-ci-gates.md
+│   │   ├── branch-protection-and-ci-gates.md
+│   │   └── labels-and-triage.md
 │   ├── workflows/
 │   │   └── workflow-levels.md
 │   ├── experiments/

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Not:
 
 - **[Quickstart Guide](./docs/quickstart.md)** — step-by-step onboarding
 - **[Operations Guide](./docs/operations/one-jules-task-at-a-time.md)** — sequencing tasks safely
+- **[Labels and Triage Guide](./docs/operations/labels-and-triage.md)** — organizing work with labels
 - **[Branch Protection Guide](./docs/operations/branch-protection-and-ci-gates.md)** — CI gates and protecting `main`
 
 ### 1. Copy the Starter Kit Files
@@ -139,7 +140,8 @@ The default workflow is Level 1. Levels 5 and 6 belong in sandboxes, not unprote
 │   │   └── documentation-audit.md
 │   ├── operations/
 │   │   ├── one-jules-task-at-a-time.md
-│   │   └── branch-protection-and-ci-gates.md
+│   │   ├── branch-protection-and-ci-gates.md
+│   │   └── labels-and-triage.md
 │   ├── workflows/
 │   │   └── workflow-levels.md
 │   ├── experiments/

--- a/docs/operations/labels-and-triage.md
+++ b/docs/operations/labels-and-triage.md
@@ -1,0 +1,75 @@
+# Labels and Triage Guide
+
+This guide explains how to organize AI-assisted work using GitHub labels and a structured triage flow. A consistent labeling model helps maintainers track Jules's progress, manage experiments, and ensure a clean engineering history.
+
+## Recommended Label Categories
+
+| Category | Labels | Description |
+| --- | --- | --- |
+| **Core Tasks** | `jules`, `task` | Standard coding tasks for Jules to implement. |
+| **Experiments** | `experiment`, `workflow` | Testing advanced or non-default Jules workflows. |
+| **Content** | `documentation`, `example` | Updates to guides, READMEs, or reusable examples. |
+| **Tracking** | `case-study` | Issues related to specific case studies. |
+| **Triggers** | `run-jules` | The explicit signal to trigger a Jules run. |
+
+## Labels for Jules Tasks
+
+Use `jules` and `task` for standard issues where you want Jules to provide a focused Pull Request. These usually follow the `jules_task.yml` template.
+
+- `jules`: Identifies the issue as intended for the AI coding agent.
+- `task`: Indicates a concrete unit of work with defined acceptance criteria.
+
+## Labels for Workflow Experiments
+
+Use `experiment` and `workflow` for tasks that test new ways of working with Jules (e.g., Level 5 or Level 6 workflows). These usually follow the `workflow_experiment.yml` template.
+
+- `experiment`: Signals that the result may be non-deterministic or requires a sandbox.
+- `workflow`: Focuses on the process itself rather than a specific feature.
+
+## Labels for Documentation and Examples
+
+Use `documentation` and `example` to distinguish content-heavy tasks from code-heavy ones.
+
+- `documentation`: For core guides, README updates, or API docs.
+- `example`: For adding or refining files in the `examples/` directory.
+
+## Labels for Case Studies
+
+Use `case-study` to group issues that belong to a specific narrative or real-world application, such as the Digital Logic Circuit or the English-Only Project.
+
+## The `run-jules` Trigger
+
+The `run-jules` label is the primary mechanism for controlling when Jules starts working on an issue.
+
+1. **Explicit Trigger:** Jules should only start when the `run-jules` label is added to an issue.
+2. **Remove After Start:** Once Jules has picked up the task and opened a PR, the maintainer (or an automated script, if configured) should remove the label.
+3. **Re-triggering:** If a Jules run fails or produces an unsatisfactory PR, close the PR, address any issues in the issue description, and re-add `run-jules` to start a fresh attempt.
+
+## Avoiding Concurrent Duplicate Runs
+
+To maintain a clean history and avoid merge conflicts, follow the principle of **one Jules task at a time** on shared files.
+
+- Do not add `run-jules` to multiple issues that modify the same files (e.g., `README.md`).
+- Wait for the previous Jules PR to be merged before triggering the next related task.
+- For more details, see [One Jules Task at a Time](./one-jules-task-at-a-time.md).
+
+## Suggested Triage Flow
+
+A structured flow ensures that human maintainers remain in control of the project direction.
+
+1. **New Issue:** A human creates an issue (using a template).
+2. **Triage:** A human reviews the issue, adds category labels (`jules`, `task`, `documentation`), and ensures the scope is clear.
+3. **Trigger:** A human adds `run-jules` when ready for implementation.
+4. **Implementation:** Jules creates a branch and opens a Pull Request.
+5. **Review:** A human reviews the PR, provides feedback, or requests changes.
+6. **Merge:** A human merges the PR once it meets all acceptance criteria and passes CI.
+
+## Optional Labels
+
+Maintainers may add additional labels without overcomplicating the workflow:
+- **Priority:** `p0` (urgent), `p1` (standard), `p2` (backlog).
+- **Status:** `blocked` (waiting on human decision), `in-progress` (Jules is working).
+
+## Summary
+
+Labels in this starter kit are not just for organization—they are control signals. By using `run-jules` as an explicit trigger and following a human-led triage flow, you ensure that Jules remains a productive, managed contributor to your project.


### PR DESCRIPTION
I have added the requested Label and Triage Operations Guide.

### Changes:
1.  **New File**: Created `docs/operations/labels-and-triage.md`. This guide covers:
    *   Recommended label categories (`jules`, `task`, `experiment`, `workflow`, `documentation`, `example`, `case-study`).
    *   Detailed explanation of the `run-jules` trigger label.
    *   Safety warnings against concurrent duplicate runs.
    *   A suggested human-led triage flow from issue creation to merging.
2.  **README Updates**: Added a link to the new guide in the "Start Here" section and updated the "Repository Structure" tree in both `README.md` and `README.ko.md`.
3.  **CI Update**: Added the new file to the `required_paths` list in `.github/workflows/docs-and-templates.yml` to ensure it is maintained as a core part of the starter kit.

### Validation:
*   Verified file existence and content.
*   Ran Markdown hygiene validation (newline at EOF, no tabs, controlled trailing spaces).
*   Ran structural validation to ensure all required starter kit files (including the new one) are present.
*   Confirmed relative links in READMEs are correct.
*   Received a positive code review verifying the solution against the original requirements.

Fixes #56

---
*PR created automatically by Jules for task [10609798019086436756](https://jules.google.com/task/10609798019086436756) started by @hkimw*