### PR TITLE
docs: add label and triage operations guide

### DIFF
--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -120,6 +120,7 @@ jobs:
             "docs/quickstart.md"
             "docs/operations/one-jules-task-at-a-time.md"
             "docs/operations/branch-protection-and-ci-gates.md"
+            "docs/operations/labels-and-triage.md"
             "docs/meta/project-readiness.md"
             "docs/meta/release-checklist.md"
             "docs/meta/documentation-audit.md"

--- a/README.ko.md
+++ b/README.ko.md
@@ -48,6 +48,7 @@ graph LR
 - **[Quickstart 가이드](./docs/quickstart.md)** — 단계별 온보딩
 - **[운영 가이드](./docs/operations/one-jules-task-at-a-time.md)** — 안전한 태스크 순차 실행
 - **[브랜치 보호 가이드](./docs/operations/branch-protection-and-ci-gates.md)** — CI 게이트와 `main` 보호
+- **[라벨 및 트리아지 가이드](./docs/operations/labels-and-triage.md)** — AI 태스크 정리
 
 ### 1. Starter Kit 파일 복사하기
 
@@ -139,7 +140,8 @@ Merge 전에 다음을 확인합니다.
 │   │   └── documentation-audit.md
 │   ├── operations/
 │   │   ├── one-jules-task-at-a-time.md
-│   │   └── branch-protection-and-ci-gates.md
+│   │   ├── branch-protection-and-ci-gates.md
+│   │   └── labels-and-triage.md
 │   ├── workflows/
 │   │   └── workflow-levels.md
 │   ├── experiments/

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Not:
 - **[Quickstart Guide](./docs/quickstart.md)** — step-by-step onboarding
 - **[Operations Guide](./docs/operations/one-jules-task-at-a-time.md)** — sequencing tasks safely
 - **[Branch Protection Guide](./docs/operations/branch-protection-and-ci-gates.md)** — CI gates and protecting `main`
+- **[Labels and Triage Guide](./docs/operations/labels-and-triage.md)** — organizing AI tasks
 
 ### 1. Copy the Starter Kit Files
 
@@ -139,7 +140,8 @@ The default workflow is Level 1. Levels 5 and 6 belong in sandboxes, not unprote
 │   │   └── documentation-audit.md
 │   ├── operations/
 │   │   ├── one-jules-task-at-a-time.md
-│   │   └── branch-protection-and-ci-gates.md
+│   │   ├── branch-protection-and-ci-gates.md
+│   │   └── labels-and-triage.md
 │   ├── workflows/
 │   │   └── workflow-levels.md
 │   ├── experiments/

--- a/docs/operations/labels-and-triage.md
+++ b/docs/operations/labels-and-triage.md
@@ -1,0 +1,47 @@
+# Labels and Triage Guide
+
+This guide explains a reusable label and triage model for maintainers organizing AI-assisted work in GitHub. It helps maintain a clean, organized queue of issues and pull requests, especially when using an explicit trigger like `run-jules`.
+
+## Recommended Label Categories
+
+To organize issues and pull requests, we recommend the following simple label taxonomy:
+
+- `jules`: Indicates an issue or PR that is assigned to or handled by Jules. This is an informational label.
+- `run-jules`: An explicit trigger label used to signal automation to start working on an issue.
+- `workflow`: Used for issues discussing or documenting the Jules workflow itself.
+- `documentation`: Applied to tasks focused on updating or writing documentation.
+- `case-study`: Used for issues tracking the creation or progress of case studies.
+
+You can also use optional standard labels for priority or status (e.g., `bug`, `enhancement`, `help wanted`) without overcomplicating the repository.
+
+## Using `run-jules` as an Explicit Trigger
+
+The `run-jules` label acts as an explicit start button for automation.
+
+- **Adding the label:** A maintainer adds `run-jules` when an issue is scoped, reviewed, and ready for the AI agent to begin work.
+- **Removing the label:** Automation (or the maintainer) should remove the label once the agent has acknowledged the task or created the PR, indicating the run has started or finished.
+- **Re-adding the label:** If the PR needs significant revision or if a new iteration is required based on PR review comments, the maintainer can re-add `run-jules` to trigger another run.
+
+### Avoiding Concurrent Duplicate Runs
+
+It is critical to avoid accidentally triggering concurrent duplicate Jules runs on the same issue.
+
+- **Wait for acknowledgment:** Do not add the `run-jules` label multiple times in quick succession. Wait for the agent to create a PR or comment on the issue.
+- **One task at a time:** Follow the [One Jules Task At A Time](./one-jules-task-at-a-time.md) principle to prevent merge conflicts and state confusion.
+- **Clear state:** Ensure the `run-jules` label is removed before triggering a new run for revisions.
+
+## Suggested Triage Flow
+
+This is the standard GitHub-native flow from a new issue to a merged PR:
+
+1. **New Issue Opened:** A maintainer or contributor creates an issue. It may have standard categorizing labels (like `documentation` or `bug`).
+2. **Review & Scope:** The maintainer reviews the issue to ensure it is small, focused, and appropriate for Jules.
+3. **Trigger:** The maintainer assigns the `jules` label for tracking and adds the `run-jules` label to initiate the task.
+4. **Agent Action:** The automation detects `run-jules`, removes the label, and begins work.
+5. **PR Creation:** Jules opens a Pull Request linked to the issue.
+6. **Human Review:** The maintainer reviews the PR.
+   - If approved: Merge.
+   - If changes are needed: Leave review comments. If the agent needs to completely re-plan, the maintainer may re-add `run-jules`.
+7. **Merge & Close:** Once the PR passes CI and human review, it is merged, and the issue is closed.
+
+This process keeps the default workflow **human-led**, ensuring that maintainers always own the architecture, direction, and final merge decisions.

--- a/docs/operations/labels-and-triage.md
+++ b/docs/operations/labels-and-triage.md
@@ -1,47 +1,47 @@
 # Labels and Triage Guide
 
-This guide explains a reusable label and triage model for maintainers organizing AI-assisted work in GitHub. It helps maintain a clean, organized queue of issues and pull requests, especially when using an explicit trigger like `run-jules`.
+This guide explains a reusable label and triage model for maintainers organizing AI-assisted work in GitHub. It helps maintain a clean queue of issues and pull requests, especially when using an explicit trigger like `run-jules`.
 
 ## Recommended Label Categories
 
-To organize issues and pull requests, we recommend the following simple label taxonomy:
+To organize issues and pull requests, use a small label taxonomy:
 
-- `jules`: Indicates an issue or PR that is assigned to or handled by Jules. This is an informational label.
-- `run-jules`: An explicit trigger label used to signal automation to start working on an issue.
+- `jules`: Indicates an issue or PR related to Jules-assisted work. This is an informational label.
+- `run-jules`: An explicit trigger label used to signal that an issue is ready for a Jules run.
 - `workflow`: Used for issues discussing or documenting the Jules workflow itself.
 - `documentation`: Applied to tasks focused on updating or writing documentation.
 - `case-study`: Used for issues tracking the creation or progress of case studies.
 
-You can also use optional standard labels for priority or status (e.g., `bug`, `enhancement`, `help wanted`) without overcomplicating the repository.
+You can also use optional standard labels for priority or status, such as `bug`, `enhancement`, or `help wanted`, without overcomplicating the repository.
 
 ## Using `run-jules` as an Explicit Trigger
 
-The `run-jules` label acts as an explicit start button for automation.
+The `run-jules` label works like a start signal.
 
-- **Adding the label:** A maintainer adds `run-jules` when an issue is scoped, reviewed, and ready for the AI agent to begin work.
-- **Removing the label:** Automation (or the maintainer) should remove the label once the agent has acknowledged the task or created the PR, indicating the run has started or finished.
-- **Re-adding the label:** If the PR needs significant revision or if a new iteration is required based on PR review comments, the maintainer can re-add `run-jules` to trigger another run.
+- **Adding the label:** A maintainer adds `run-jules` when an issue is scoped, reviewed, and ready for Jules to begin work.
+- **Removing the label:** The label should be removed once the run has started or a PR has been opened.
+- **Re-adding the label:** If the PR needs a new attempt, close or review the current PR first, update the issue with clearer instructions, and then re-add `run-jules`.
 
-### Avoiding Concurrent Duplicate Runs
+## Avoiding Concurrent Duplicate Runs
 
-It is critical to avoid accidentally triggering concurrent duplicate Jules runs on the same issue.
+Avoid triggering multiple Jules runs for the same issue or for overlapping files.
 
-- **Wait for acknowledgment:** Do not add the `run-jules` label multiple times in quick succession. Wait for the agent to create a PR or comment on the issue.
-- **One task at a time:** Follow the [One Jules Task At A Time](./one-jules-task-at-a-time.md) principle to prevent merge conflicts and state confusion.
-- **Clear state:** Ensure the `run-jules` label is removed before triggering a new run for revisions.
+- Do not add `run-jules` multiple times in quick succession.
+- Wait for Jules to create a PR or comment on the issue before triggering another run.
+- Follow the [One Jules Task At A Time](./one-jules-task-at-a-time.md) principle to prevent merge conflicts and duplicated work.
+- Remove `run-jules` before starting a later revision.
 
 ## Suggested Triage Flow
 
 This is the standard GitHub-native flow from a new issue to a merged PR:
 
-1. **New Issue Opened:** A maintainer or contributor creates an issue. It may have standard categorizing labels (like `documentation` or `bug`).
-2. **Review & Scope:** The maintainer reviews the issue to ensure it is small, focused, and appropriate for Jules.
-3. **Trigger:** The maintainer assigns the `jules` label for tracking and adds the `run-jules` label to initiate the task.
-4. **Agent Action:** The automation detects `run-jules`, removes the label, and begins work.
-5. **PR Creation:** Jules opens a Pull Request linked to the issue.
-6. **Human Review:** The maintainer reviews the PR.
-   - If approved: Merge.
-   - If changes are needed: Leave review comments. If the agent needs to completely re-plan, the maintainer may re-add `run-jules`.
-7. **Merge & Close:** Once the PR passes CI and human review, it is merged, and the issue is closed.
+1. **New Issue Opened:** A maintainer or contributor creates an issue. It may have standard labels like `documentation` or `bug`.
+2. **Review and Scope:** The maintainer reviews the issue to ensure it is small, focused, and appropriate for Jules.
+3. **Trigger:** The maintainer adds `jules` for tracking and `run-jules` when the task is ready.
+4. **Jules Run:** Jules works on the task and opens a pull request.
+5. **Human Review:** The maintainer reviews the PR.
+   - If approved: merge.
+   - If changes are needed: leave review comments or update the issue before another run.
+6. **Merge and Close:** Once the PR passes CI and human review, merge it and close the issue.
 
-This process keeps the default workflow **human-led**, ensuring that maintainers always own the architecture, direction, and final merge decisions.
+This process keeps the default workflow **human-led**. The maintainer owns the architecture, direction, review, and final merge decision.


### PR DESCRIPTION
Fixes #56. Added `docs/operations/labels-and-triage.md` to document reusable label and triage models for maintainers adopting the Jules workflow. Included `run-jules` trigger usage and duplicate run warnings. Updated `.github/workflows/docs-and-templates.yml` to require the new file. Added relative links to READMEs.

---
*PR created automatically by Jules for task [6093147872959756694](https://jules.google.com/task/6093147872959756694) started by @hkimw*