### PR TITLE
Restructure README around four workflow tracks

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,221 +1,73 @@
-# AI Coding Workflow Starter Kit for Jules
+# Jules를 위한 AI 코딩 워크플로우 스타터 키트
 
 [English](./README.md) · [한국어](./README.ko.md) · [프로젝트 준비 상태](./docs/meta/project-readiness.md) · [출시 체크리스트](./docs/meta/release-checklist.md) · [기여하기](./CONTRIBUTING.md) · [행동 강령](./CODE_OF_CONDUCT.md) · [보안](./SECURITY.md)
 
 > 대부분의 AI 코딩 데모는 완성된 코드만 보여줍니다.  
 > 이 프로젝트는 그 과정 자체를 보여줍니다.
 
-**AI Coding Workflow Starter Kit for Jules**는 Jules를 GitHub Issue, Pull Request, Review, CI, case study, controlled automation 안에서 운영하기 위한 GitHub-native starter kit입니다.
-
-이 저장소는 AI-assisted work가 읽을 수 있는 engineering history를 남기도록 돕습니다.
-
-```mermaid
-graph LR
-    Issue --> Task[Jules task]
-    Task --> PR[Pull request]
-    PR --> CI
-    CI --> Review[Human review]
-    Review --> Merge
-    Review -.->|Request changes| Task
-```
-
-단순한 prompt 모음이 아니라 template, example, review checklist, CI gate, case study를 포함한 reusable workflow kit입니다.
+**AI Coding Workflow Starter Kit for Jules**는 AI 코딩 에이전트인 Jules를 전문적인 엔지니어링 프로세스로 이끌기 위한 GitHub 네이티브 플레이북입니다. AI 보조 작업을 "마법 같은 프롬프트"에서 벗어나 Issue, Pull Request, Review, CI의 영역으로 옮깁니다.
 
 ---
 
-## What You Get
+## 트랙 선택하기
 
-- Jules task를 위한 scoped GitHub Issue template
-- linked issue와 validation notes를 요구하는 PR template
-- approve/request changes용 maintainer review example
-- Markdown, YAML, required starter kit file을 확인하는 lightweight CI
-- human-led workflow부터 sandbox-only automation experiment까지 나눈 workflow levels
-- issue handoff와 daily maintainer report용 prompt
-- 실제 프로젝트에 workflow를 적용한 case study
+Jules와 어떻게 일하고 싶으신가요? 목표에 맞는 트랙을 선택하세요.
 
-핵심 메시지는 단순합니다.
-
-> Human maintainer가 AI coding agent를 일반적인 GitHub engineering practice 안에서 리드한다.
-
-아래 메시지가 아닙니다.
-
-> AI가 프로젝트 전체를 혼자 만들었다.
-
----
-
-## Start Here
-
-- **[Quickstart 가이드](./docs/quickstart.md)** — 단계별 온보딩
-- **[운영 가이드](./docs/operations/one-jules-task-at-a-time.md)** — 안전한 태스크 순차 실행
-- **[브랜치 보호 가이드](./docs/operations/branch-protection-and-ci-gates.md)** — CI 게이트와 `main` 보호
-- **[라벨 및 트리아지 가이드](./docs/operations/labels-and-triage.md)** — AI 태스크 정리
-
-### 1. Starter Kit 파일 복사하기
-
-자기 repository에 먼저 아래 파일들을 복사합니다.
-
-```text
-AGENTS.md
-.github/ISSUE_TEMPLATE/
-.github/PULL_REQUEST_TEMPLATE.md
-.github/workflows/docs-and-templates.yml
-prompts/
-examples/
-```
-
-### 2. 작은 Issue 하나 열기
-
-좋은 issue:
-
-```text
-Add a PR template that requires a linked issue, validation steps, and a reviewer checklist.
-```
-
-나쁜 issue:
-
-```text
-Improve the project.
-```
-
-### 3. Issue를 Jules에게 넘기기
-
-Issue를 source of truth로 사용합니다. Jules는 issue를 대체하는 것이 아니라 focused PR을 만들어야 합니다.
-
-### 4. Merge 전 Review하기
-
-Merge 전에 다음을 확인합니다.
-
-- PR이 linked issue를 해결하는가?
-- scope가 통제되어 있는가?
-- 관련 없는 파일이 바뀌지 않았는가?
-- tests 또는 validation steps가 포함되어 있는가?
-- CI가 통과하는가?
-- 나중에 다른 개발자가 이 history를 이해할 수 있는가?
-
----
-
-## Workflow Levels
-
-이 starter kit은 안정적인 maintainer workflow와 실험적 automation을 분리합니다.
-
-| Level | Workflow | Human role | Status |
+| 트랙 | 목표 | 추천 대상 | 레벨 |
 | --- | --- | --- | --- |
-| 1 | Human-led Jules workflow | issue 작성, PR review, merge | recommended default |
-| 2 | Semi-autonomous Jules workflow | issue 작성, final PR review | practical advanced mode |
-| 3 | Human issue only | issue만 작성, Jules가 implementation/PR update | advanced with strict CI |
-| 4 | Daily agentic maintainer loop | daily report를 보고 방향 조정 | advanced planning loop |
-| 5 | No-human sandbox workflow | 관찰 또는 audit만 수행 | experiment only |
-| 6 | Jules + evaluator-driven evolution | objective/evaluator 정의, 결과 review | experiment only |
-
-기본값은 Level 1입니다. Level 5와 6은 sandbox 또는 protected experiment branch에서만 다룹니다.
+| **Review-Driven** | **기본 권장.** 높은 품질과 깔끔한 이력. | 모두에게 권장 | 1 |
+| **GitHub-Native Collaboration** | 전문적인 워크플로우 학습. | 학생 및 교사 | 1 |
+| **Half Vibe Coding** | CI 게이트를 활용한 빠른 반복 작업. | 숙련된 사용자 | 2-3 |
+| **Full Vibe Coding** | **실험적.** 자율적인 샌드박스 실험. | 연구자 및 실험가 | 5-6 |
 
 ---
 
-## Repository Structure
+## 시작하기
 
-```text
-.
-├── README.md
-├── README.ko.md
-├── AGENTS.md
-├── CONTRIBUTING.md
-├── CODE_OF_CONDUCT.md
-├── SECURITY.md
-├── LICENSE
-├── .github/
-│   ├── ISSUE_TEMPLATE/
-│   │   ├── jules_task.yml
-│   │   └── workflow_experiment.yml
-│   ├── workflows/
-│   │   └── docs-and-templates.yml
-│   └── PULL_REQUEST_TEMPLATE.md
-├── examples/
-│   ├── issues/
-│   └── pr-reviews/
-├── docs/
-│   ├── quickstart.md
-│   ├── meta/
-│   │   ├── project-readiness.md
-│   │   ├── release-checklist.md
-│   │   └── documentation-audit.md
-│   ├── operations/
-│   │   ├── one-jules-task-at-a-time.md
-│   │   ├── branch-protection-and-ci-gates.md
-│   │   └── labels-and-triage.md
-│   ├── workflows/
-│   │   └── workflow-levels.md
-│   ├── experiments/
-│   │   ├── no-human-only-jules-workflow.md
-│   │   └── jules-alpha-evolve.md
-│   └── case-studies/
-│       ├── digital-logic-circuit.md
-│       └── english-only-project.md
-└── prompts/
-    ├── issue-to-jules-task.md
-    └── daily-maintainer-report.md
-```
+1. **[Quickstart 가이드](./docs/quickstart.md)** — 첫 번째 Jules 태스크를 시작하기 위한 단계별 온보딩.
+2. **스타터 키트 복사** — `AGENTS.md`, `.github/`, `prompts/` 폴더를 프로젝트에 추가하세요.
+3. **Issue 열기** — Jules가 해결할 작고 명확한 태스크를 정의하세요.
+4. **Review & Merge** — PR과 CI 프로세스를 통해 Jules를 리드하세요.
 
 ---
 
-## Case Studies
+## 기본 워크플로우 작동 방식
 
-### [Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)
+**Review-Driven** 트랙은 이 프로젝트가 권장하는 표준 방식입니다. 사람이 아키텍처를 통제하고 Jules가 구현을 담당하도록 보장합니다.
 
-Repository: <https://github.com/hkimw-underground/digital-logic-circuit>
-
-실제 hardware/software capstone case study입니다. planning과 implementation을 GitHub Issues, PRs, human review, Jules-assisted implementation 중심으로 옮기는 사례입니다.
-
-Architecture, hardware constraints, scope, review, final merge decision은 maintainer가 책임집니다.
-
-### [Case Study B: English-Only Open Source Project](./docs/case-studies/english-only-project.md)
-
-Status: planned (`md-link-linter`).
-
-글로벌 독자를 위한 예정된 순수 영어 case study입니다. 학교/capstone 맥락 밖에서도 minimalist Markdown link checker 제작 과정을 통해 small issues, focused Jules PRs, CI-first development, readable review comments가 재사용 가능하다는 것을 보여주는 목적입니다.
+1. **Issue**: 메인테이너가 구체적인 태스크를 정의합니다.
+2. **Task**: Jules가 변경 사항을 계획하고 구현합니다.
+3. **Pull Request**: Jules가 해당 Issue와 연결된 PR을 생성합니다.
+4. **CI**: 자동화된 체크를 통해 변경 사항을 검증합니다.
+5. **Review**: 메인테이너가 코드를 리뷰하고 필요한 경우 수정을 요청합니다.
+6. **Merge**: 메인테이너가 최종 머지 결정을 내립니다.
 
 ---
 
-## Safety Position
+## 포함된 내용
 
-이 저장소는 automation을 다루지만, automation 자체를 기본 목표로 삼지 않습니다.
-
-Stable guidance:
-
-```text
-Human decides direction.
-Human owns architecture.
-Human reviews final changes.
-CI gates every merge.
-Jules is never presented as a human contributor.
-```
-
-Experimental guidance:
-
-```text
-No-human workflows must run in sandbox repos or protected branches.
-Auto-merge requires strict CI and branch protection.
-Evaluator-driven evolution must use measurable tests or benchmarks.
-```
+- **범위가 제한된 Issue 템플릿**: Jules 태스크 및 실험을 위해 사전 설정됨.
+- **PR 템플릿**: 검증 체크리스트가 포함된 표준화된 형식.
+- **워크플로우 레벨**: 사람 주도 태스크부터 실험적 자율성까지 단계별 구분.
+- **참조 예시**: 실제 Issue 및 메인테이너 리뷰 사례.
+- **CI 검증**: Markdown 및 YAML 위생을 위한 가벼운 체크 도구.
+- **재사용 가능한 프롬프트**: 업무 전달 및 상태 보고용 템플릿.
 
 ---
 
-## Why This Exists
+## 케이스 스터디
 
-대부분의 AI coding demo는 완성된 코드만 보여줍니다.
+- **[Case Study A: 디지털 논리 회로](./docs/case-studies/digital-logic-circuit.md)** — Jules 워크플로우를 적용한 하드웨어/소프트웨어 캡스톤 프로젝트.
+- **[Case Study B: md-link-linter](./docs/case-studies/english-only-project.md)** — (예정) CI 우선 접근 방식으로 구축된 미니멀 Markdown 링크 체커.
 
-이 프로젝트는 과정을 보여줍니다.
+---
 
-```text
-Issue.
-Prompt.
-Plan.
-Pull request.
-Review.
-CI.
-History.
-```
+## 안전 및 책임
 
-진짜 AI-assisted engineering은 여기서 일어납니다.
+- **사람 중심**: 사람이 방향을 결정하고 아키텍처를 소유합니다.
+- **에이전트로서의 Jules**: Jules는 AI 코딩 에이전트이며, 인간 기여자로 포장되지 않습니다.
+- **CI 게이트**: 모든 머지는 자동화된 체크(CI)를 통과해야 합니다.
+- **실험용 샌드박스**: Full Vibe Coding은 반드시 샌드박스 환경에서만 수행되어야 합니다.
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,76 +1,150 @@
 # Jules를 위한 AI 코딩 워크플로우 스타터 키트
 
-[English](./README.md) · [한국어](./README.ko.md) · [프로젝트 준비 상태](./docs/meta/project-readiness.md) · [출시 체크리스트](./docs/meta/release-checklist.md) · [기여하기](./CONTRIBUTING.md) · [행동 강령](./CODE_OF_CONDUCT.md) · [보안](./SECURITY.md)
+[English](./README.md) · [한국어](./README.ko.md) · [Quickstart](./docs/quickstart.md) · [프로젝트 준비 상태](./docs/meta/project-readiness.md) · [출시 체크리스트](./docs/meta/release-checklist.md) · [기여하기](./CONTRIBUTING.md) · [보안](./SECURITY.md)
 
 > 대부분의 AI 코딩 데모는 완성된 코드만 보여줍니다.  
 > 이 프로젝트는 그 과정 자체를 보여줍니다.
 
-**AI Coding Workflow Starter Kit for Jules**는 AI 코딩 에이전트인 Jules를 전문적인 엔지니어링 프로세스로 이끌기 위한 GitHub 네이티브 플레이북입니다. AI 보조 작업을 "마법 같은 프롬프트"에서 벗어나 Issue, Pull Request, Review, CI의 영역으로 옮깁니다.
+**AI Coding Workflow Starter Kit for Jules**는 Jules를 GitHub Issue, Pull Request, Review, CI, case study, controlled workflow experiment 안에서 운영하기 위한 GitHub-native playbook입니다.
+
+학생, 교사, 처음 GitHub를 쓰는 maintainer, 작은 팀이 AI-assisted coding work를 읽을 수 있는 engineering history로 남기도록 돕는 것이 목표입니다.
+
+단순한 prompt 모음이 아닙니다. 일반적인 GitHub practice 안에서 AI-assisted work를 운영하기 위한 reusable starter kit입니다.
 
 ---
 
 ## 트랙 선택하기
 
-Jules와 어떻게 일하고 싶으신가요? 목표에 맞는 트랙을 선택하세요.
+원하는 인간 개입 수준에 맞는 workflow를 고르세요.
 
-| 트랙 | 목표 | 추천 대상 | 레벨 |
+| 트랙 | 적합한 상황 | 인간 개입 | 상태 |
 | --- | --- | --- | --- |
-| **Review-Driven** | **기본 권장.** 높은 품질과 깔끔한 이력. | 모두에게 권장 | 1 |
-| **GitHub-Native Collaboration** | 전문적인 워크플로우 학습. | 학생 및 교사 | 1 |
-| **Half Vibe Coding** | CI 게이트를 활용한 빠른 반복 작업. | 숙련된 사용자 | 2-3 |
-| **Full Vibe Coding** | **실험적.** 자율적인 샌드박스 실험. | 연구자 및 실험가 | 5-6 |
+| **Review-Driven** | 실제 프로젝트, 수업, starter repo | 중간 | **기본 권장** |
+| **GitHub-Native Collaboration** | Issue, PR, review, CI, label, branch protection 학습 | 중간 | 학습용 권장 |
+| **Half Vibe Coding** | maintainer가 방향을 주고 Jules가 checkpoint 사이를 실행 | 낮음 | 고급 |
+| **Full Vibe Coding** | sandbox experiment와 workflow research | 최소 | 실험 전용 |
+
+대부분의 독자에게 추천하는 순서:
+
+```text
+Review-Driven으로 시작합니다.
+GitHub 협업을 가르치거나 배울 때 GitHub-Native Collaboration을 사용합니다.
+CI와 review rule이 잡힌 뒤에 Half Vibe Coding을 시도합니다.
+Full Vibe Coding은 sandbox repo 또는 protected branch에서만 다룹니다.
+```
 
 ---
 
 ## 시작하기
 
-1. **[Quickstart 가이드](./docs/quickstart.md)** — 첫 번째 Jules 태스크를 시작하기 위한 단계별 온보딩.
-2. **스타터 키트 복사** — `AGENTS.md`, `.github/`, `prompts/` 폴더를 프로젝트에 추가하세요.
-3. **Issue 열기** — Jules가 해결할 작고 명확한 태스크를 정의하세요.
-4. **Review & Merge** — PR과 CI 프로세스를 통해 Jules를 리드하세요.
+1. **[Quickstart Guide](./docs/quickstart.md)**를 읽습니다.
+2. starter file을 자신의 repository에 복사합니다.
+3. 작은 GitHub Issue를 엽니다.
+4. Jules가 focused pull request를 만들게 합니다.
+5. PR을 review하고, CI를 확인한 뒤, maintainer가 만족할 때만 merge합니다.
+
+먼저 복사할 starter file:
+
+```text
+AGENTS.md
+.github/ISSUE_TEMPLATE/
+.github/PULL_REQUEST_TEMPLATE.md
+.github/workflows/docs-and-templates.yml
+prompts/
+examples/
+```
 
 ---
 
-## 기본 워크플로우 작동 방식
+## 기본 워크플로우
 
-**Review-Driven** 트랙은 이 프로젝트가 권장하는 표준 방식입니다. 사람이 아키텍처를 통제하고 Jules가 구현을 담당하도록 보장합니다.
+기본 workflow는 **Review-Driven**입니다.
 
-1. **Issue**: 메인테이너가 구체적인 태스크를 정의합니다.
-2. **Task**: Jules가 변경 사항을 계획하고 구현합니다.
-3. **Pull Request**: Jules가 해당 Issue와 연결된 PR을 생성합니다.
-4. **CI**: 자동화된 체크를 통해 변경 사항을 검증합니다.
-5. **Review**: 메인테이너가 코드를 리뷰하고 필요한 경우 수정을 요청합니다.
-6. **Merge**: 메인테이너가 최종 머지 결정을 내립니다.
+```text
+Issue → Jules task → Pull request → CI → Human review → Merge
+```
+
+Maintainer는 scope, architecture, validation, final merge decision을 계속 책임집니다. Jules는 GitHub workflow 안에서 implementation과 documentation 작업을 보조합니다.
 
 ---
 
 ## 포함된 내용
 
-- **범위가 제한된 Issue 템플릿**: Jules 태스크 및 실험을 위해 사전 설정됨.
-- **PR 템플릿**: 검증 체크리스트가 포함된 표준화된 형식.
-- **워크플로우 레벨**: 사람 주도 태스크부터 실험적 자율성까지 단계별 구분.
-- **참조 예시**: 실제 Issue 및 메인테이너 리뷰 사례.
-- **CI 검증**: Markdown 및 YAML 위생을 위한 가벼운 체크 도구.
-- **재사용 가능한 프롬프트**: 업무 전달 및 상태 보고용 템플릿.
+- **AGENTS.md** — Jules-assisted work를 위한 repository rule
+- **Issue templates** — scoped task와 workflow experiment template
+- **PR template** — linked issue, validation, review expectation
+- **CI example** — docs와 starter kit 구조를 확인하는 lightweight check
+- **Prompts** — issue handoff와 maintainer report prompt
+- **Examples** — reusable issue와 PR review example
+- **Operations guides** — one-task-at-a-time, branch protection, labels, triage
+- **Case studies** — 실제 적용 사례 1개와 planned English-only case study 1개
+
+---
+
+## 주요 가이드
+
+- [Quickstart](./docs/quickstart.md)
+- [One Jules Task at a Time](./docs/operations/one-jules-task-at-a-time.md)
+- [Branch Protection and CI Gates](./docs/operations/branch-protection-and-ci-gates.md)
+- [Labels and Triage](./docs/operations/labels-and-triage.md)
+- [Project Readiness](./docs/meta/project-readiness.md)
+- [Documentation Audit](./docs/meta/documentation-audit.md)
 
 ---
 
 ## 케이스 스터디
 
-- **[Case Study A: 디지털 논리 회로](./docs/case-studies/digital-logic-circuit.md)** — Jules 워크플로우를 적용한 하드웨어/소프트웨어 캡스톤 프로젝트.
-- **[Case Study B: md-link-linter](./docs/case-studies/english-only-project.md)** — (예정) CI 우선 접근 방식으로 구축된 미니멀 Markdown 링크 체커.
+- **[Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)** — Jules workflow를 적용한 실제 hardware/software capstone project.
+- **[Case Study B: English-Only Project Brief](./docs/case-studies/english-only-project.md)** — 글로벌 독자를 위한 작은 open-source project 계획 문서.
 
 ---
 
 ## 안전 및 책임
 
-- **사람 중심**: 사람이 방향을 결정하고 아키텍처를 소유합니다.
-- **에이전트로서의 Jules**: Jules는 AI 코딩 에이전트이며, 인간 기여자로 포장되지 않습니다.
-- **CI 게이트**: 모든 머지는 자동화된 체크(CI)를 통과해야 합니다.
-- **실험용 샌드박스**: Full Vibe Coding은 반드시 샌드박스 환경에서만 수행되어야 합니다.
+Stable guidance:
+
+```text
+Human decides direction.
+Human owns architecture.
+Human reviews final changes.
+CI gates every merge.
+Jules is an AI coding agent, not a human contributor.
+```
+
+Experimental guidance:
+
+```text
+Autonomous workflows belong in sandbox repos or protected branches.
+Auto-merge experiments require strict CI and branch protection.
+Evaluator-driven experiments need measurable tests or benchmarks.
+```
+
+---
+
+## Repository Structure
+
+```text
+.
+├── AGENTS.md
+├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   ├── PULL_REQUEST_TEMPLATE.md
+│   └── workflows/
+├── docs/
+│   ├── quickstart.md
+│   ├── case-studies/
+│   ├── experiments/
+│   ├── meta/
+│   ├── operations/
+│   └── workflows/
+├── examples/
+│   ├── issues/
+│   └── pr-reviews/
+└── prompts/
+```
 
 ---
 
 ## 라이선스
 
-이 프로젝트는 [MIT 라이선스](./LICENSE)를 따릅니다.
+이 프로젝트는 [MIT License](./LICENSE)를 따릅니다.

--- a/README.md
+++ b/README.md
@@ -5,217 +5,69 @@
 > Most AI coding demos show only the final code.  
 > This project shows the process.
 
-**AI Coding Workflow Starter Kit for Jules** is a GitHub-native starter kit for leading Jules through issues, pull requests, reviews, CI, case studies, and controlled automation.
-
-It is built for maintainers who want AI-assisted work to leave a clean engineering history:
-
-```mermaid
-graph LR
-    Issue --> Task[Jules task]
-    Task --> PR[Pull request]
-    PR --> CI
-    CI --> Review[Human review]
-    Review --> Merge
-    Review -.->|Request changes| Task
-```
-
-This is not a prompt dump. It is a reusable workflow kit with templates, examples, review checklists, CI gates, and case studies.
+**AI Coding Workflow Starter Kit for Jules** is a GitHub-native playbook for leading Jules—an AI coding agent—through a professional engineering process. It moves AI-assisted work out of "magic prompts" and into issues, pull requests, reviews, and CI.
 
 ---
 
-## What You Get
+## Choose Your Track
 
-- scoped GitHub Issue templates for Jules tasks
-- PR templates that require linked issues and validation notes
-- maintainer review examples for approving or requesting changes
-- lightweight CI checks for Markdown, YAML, and required starter kit files
-- workflow levels from human-led work to sandbox-only automation experiments
-- prompts for issue handoff and daily maintainer reports
-- case studies showing how the workflow applies to real projects
+How do you want to work with Jules? Pick the track that fits your goals.
 
-The core idea is simple:
-
-> A human maintainer leads an AI coding agent through normal GitHub engineering practice.
-
-Not:
-
-> AI built the whole project by itself.
+| Track | Goal | Recommended for | Level |
+| --- | --- | --- | --- |
+| **Review-Driven** | **Default.** High quality, clean history. | Everyone | 1 |
+| **GitHub-Native Collaboration** | Learning the professional workflow. | Students & Teachers | 1 |
+| **Half Vibe Coding** | Low-touch, fast iteration with CI gates. | Advanced users | 2-3 |
+| **Full Vibe Coding** | **Experimental.** Autonomous sandboxing. | Researchers | 5-6 |
 
 ---
 
 ## Start Here
 
-- **[Quickstart Guide](./docs/quickstart.md)** — step-by-step onboarding
-- **[Operations Guide](./docs/operations/one-jules-task-at-a-time.md)** — sequencing tasks safely
-- **[Branch Protection Guide](./docs/operations/branch-protection-and-ci-gates.md)** — CI gates and protecting `main`
-- **[Labels and Triage Guide](./docs/operations/labels-and-triage.md)** — organizing AI tasks
-
-### 1. Copy the Starter Kit Files
-
-Start with these files in your own repository:
-
-```text
-AGENTS.md
-.github/ISSUE_TEMPLATE/
-.github/PULL_REQUEST_TEMPLATE.md
-.github/workflows/docs-and-templates.yml
-prompts/
-examples/
-```
-
-### 2. Open a Small Issue
-
-Good issue:
-
-```text
-Add a PR template that requires a linked issue, validation steps, and a reviewer checklist.
-```
-
-Bad issue:
-
-```text
-Improve the project.
-```
-
-### 3. Hand the Issue to Jules
-
-Use the issue as the source of truth. Jules should produce a focused PR, not replace the issue.
-
-### 4. Review Before Merge
-
-Before merging, check:
-
-- Does the PR solve the linked issue?
-- Is the scope controlled?
-- Are unrelated files changed?
-- Are tests or validation steps included?
-- Does CI pass?
-- Would another developer understand this history later?
+1. **[Quickstart Guide](./docs/quickstart.md)** — Step-by-step onboarding for your first Jules task.
+2. **Copy the Starter Kit** — Add `AGENTS.md`, `.github/`, and `prompts/` to your repository.
+3. **Open an Issue** — Define a small, scoped task for Jules to solve.
+4. **Review & Merge** — Lead Jules through the PR and CI process.
 
 ---
 
-## Workflow Levels
+## How the Default Workflow Works
 
-This starter kit separates stable maintainer workflows from experimental automation.
+The **Review-Driven** track is our recommended standard. It ensures that humans remain in control of the architecture while Jules handles the implementation.
 
-| Level | Workflow | Human role | Status |
-| --- | --- | --- | --- |
-| 1 | Human-led Jules workflow | creates issue, reviews PR, merges | recommended default |
-| 2 | Semi-autonomous Jules workflow | creates issue, reviews final PR | practical advanced mode |
-| 3 | Human issue only | writes issue; Jules handles implementation and PR updates | advanced with strict CI |
-| 4 | Daily agentic maintainer loop | steers direction from daily reports | advanced planning loop |
-| 5 | No-human sandbox workflow | observes or audits only | experiment only |
-| 6 | Jules + evaluator-driven evolution | defines objective/evaluator and reviews result | experiment only |
-
-The default workflow is Level 1. Levels 5 and 6 belong in sandboxes, not unprotected production branches.
+1. **Issue**: A human maintainer defines a scoped task.
+2. **Task**: Jules plans and implements the change.
+3. **Pull Request**: Jules opens a PR linked to the issue.
+4. **CI**: Automated checks validate the change.
+5. **Review**: A human maintainer reviews the code and requests changes if needed.
+6. **Merge**: The human maintainer makes the final decision to merge.
 
 ---
 
-## Repository Structure
+## What This Repo Includes
 
-```text
-.
-├── README.md
-├── README.ko.md
-├── AGENTS.md
-├── CONTRIBUTING.md
-├── CODE_OF_CONDUCT.md
-├── SECURITY.md
-├── LICENSE
-├── .github/
-│   ├── ISSUE_TEMPLATE/
-│   │   ├── jules_task.yml
-│   │   └── workflow_experiment.yml
-│   ├── workflows/
-│   │   └── docs-and-templates.yml
-│   └── PULL_REQUEST_TEMPLATE.md
-├── examples/
-│   ├── issues/
-│   └── pr-reviews/
-├── docs/
-│   ├── quickstart.md
-│   ├── meta/
-│   │   ├── project-readiness.md
-│   │   ├── release-checklist.md
-│   │   └── documentation-audit.md
-│   ├── operations/
-│   │   ├── one-jules-task-at-a-time.md
-│   │   ├── branch-protection-and-ci-gates.md
-│   │   └── labels-and-triage.md
-│   ├── workflows/
-│   │   └── workflow-levels.md
-│   ├── experiments/
-│   │   ├── no-human-only-jules-workflow.md
-│   │   └── jules-alpha-evolve.md
-│   └── case-studies/
-│       ├── digital-logic-circuit.md
-│       └── english-only-project.md
-└── prompts/
-    ├── issue-to-jules-task.md
-    └── daily-maintainer-report.md
-```
+- **Scoped Issue Templates**: Pre-configured for Jules tasks and experiments.
+- **PR Templates**: Standardized format with validation checklists.
+- **Workflow Levels**: From human-led tasks to experimental autonomy.
+- **Reference Examples**: Real-world issues and maintainer review examples.
+- **CI Validation**: Lightweight checks for Markdown and YAML hygiene.
+- **Reusable Prompts**: Templates for handoffs and status reporting.
 
 ---
 
 ## Case Studies
 
-### [Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)
-
-Repository: <https://github.com/hkimw-underground/digital-logic-circuit>
-
-A real hardware/software capstone case study showing how planning and implementation can move into GitHub Issues, PRs, human review, and Jules-assisted implementation.
-
-The maintainer owns architecture, hardware constraints, scope, review, and final merge decisions.
-
-### [Case Study B: English-Only Open Source Project](./docs/case-studies/english-only-project.md)
-
-Status: planned (`md-link-linter`).
-
-A planned English-only case study for a global audience. It will demonstrate the same workflow outside a school/capstone context by building a minimalist Markdown link checker: small issues, focused Jules PRs, CI-first development, and readable review comments.
+- **[Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)** — A hardware/software capstone project using the Jules workflow.
+- **[Case Study B: md-link-linter](./docs/case-studies/english-only-project.md)** — (Planned) A minimalist Markdown link checker built with a CI-first approach.
 
 ---
 
-## Safety Position
+## Safety & Ownership
 
-This repository supports automation, but it does not treat automation as the default goal.
-
-Stable guidance:
-
-```text
-Human decides direction.
-Human owns architecture.
-Human reviews final changes.
-CI gates every merge.
-Jules is never presented as a human contributor.
-```
-
-Experimental guidance:
-
-```text
-No-human workflows must run in sandbox repos or protected branches.
-Auto-merge requires strict CI and branch protection.
-Evaluator-driven evolution must use measurable tests or benchmarks.
-```
-
----
-
-## Why This Exists
-
-Most AI coding demos show only the final code.
-
-This project shows the process:
-
-```text
-Issue.
-Prompt.
-Plan.
-Pull request.
-Review.
-CI.
-History.
-```
-
-That is where real AI-assisted engineering happens.
+- **Human-Led**: A human decides the direction and owns the architecture.
+- **Jules as an Agent**: Jules is an AI coding agent, not a human contributor.
+- **CI Gates**: Every merge should be gated by automated checks.
+- **Sandbox for Experiments**: Full Vibe Coding must stay in sandbox environments.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,73 +1,147 @@
 # AI Coding Workflow Starter Kit for Jules
 
-[English](./README.md) · [한국어](./README.ko.md) · [Project Readiness](./docs/meta/project-readiness.md) · [Launch Checklist](./docs/meta/release-checklist.md) · [Contributing](./CONTRIBUTING.md) · [Code of Conduct](./CODE_OF_CONDUCT.md) · [Security](./SECURITY.md)
+[English](./README.md) · [한국어](./README.ko.md) · [Quickstart](./docs/quickstart.md) · [Project Readiness](./docs/meta/project-readiness.md) · [Launch Checklist](./docs/meta/release-checklist.md) · [Contributing](./CONTRIBUTING.md) · [Security](./SECURITY.md)
 
 > Most AI coding demos show only the final code.  
 > This project shows the process.
 
-**AI Coding Workflow Starter Kit for Jules** is a GitHub-native playbook for leading Jules—an AI coding agent—through a professional engineering process. It moves AI-assisted work out of "magic prompts" and into issues, pull requests, reviews, and CI.
+**AI Coding Workflow Starter Kit for Jules** is a GitHub-native playbook for working with Jules through issues, pull requests, reviews, CI, case studies, and controlled workflow experiments.
+
+It is built for students, teachers, first-time maintainers, and small teams who want AI-assisted coding work to leave a readable engineering history.
+
+This is not a prompt dump. It is a reusable starter kit for running AI-assisted work inside normal GitHub practice.
 
 ---
 
 ## Choose Your Track
 
-How do you want to work with Jules? Pick the track that fits your goals.
+Pick the workflow that matches how much human involvement you want.
 
-| Track | Goal | Recommended for | Level |
+| Track | Best for | Human involvement | Status |
 | --- | --- | --- | --- |
-| **Review-Driven** | **Default.** High quality, clean history. | Everyone | 1 |
-| **GitHub-Native Collaboration** | Learning the professional workflow. | Students & Teachers | 1 |
-| **Half Vibe Coding** | Low-touch, fast iteration with CI gates. | Advanced users | 2-3 |
-| **Full Vibe Coding** | **Experimental.** Autonomous sandboxing. | Researchers | 5-6 |
+| **Review-Driven** | Real projects, classrooms, starter repos | Medium | **Recommended default** |
+| **GitHub-Native Collaboration** | Learning Issues, PRs, reviews, CI, labels, and branch protection | Medium | Recommended for learning |
+| **Half Vibe Coding** | Direction from a maintainer, execution by Jules between checkpoints | Low | Advanced |
+| **Full Vibe Coding** | Sandbox experiments and workflow research | Minimal | Experimental only |
+
+Recommended path for most readers:
+
+```text
+Start with Review-Driven.
+Use GitHub-Native Collaboration when teaching or learning teamwork.
+Try Half Vibe Coding only after CI and review rules are in place.
+Keep Full Vibe Coding in sandbox repositories or protected branches.
+```
 
 ---
 
 ## Start Here
 
-1. **[Quickstart Guide](./docs/quickstart.md)** — Step-by-step onboarding for your first Jules task.
-2. **Copy the Starter Kit** — Add `AGENTS.md`, `.github/`, and `prompts/` to your repository.
-3. **Open an Issue** — Define a small, scoped task for Jules to solve.
-4. **Review & Merge** — Lead Jules through the PR and CI process.
+1. Read the **[Quickstart Guide](./docs/quickstart.md)**.
+2. Copy the starter files into your repository.
+3. Open a small GitHub Issue.
+4. Let Jules create a focused pull request.
+5. Review the PR, check CI, and merge only when the maintainer is satisfied.
+
+Starter files to copy first:
+
+```text
+AGENTS.md
+.github/ISSUE_TEMPLATE/
+.github/PULL_REQUEST_TEMPLATE.md
+.github/workflows/docs-and-templates.yml
+prompts/
+examples/
+```
 
 ---
 
-## How the Default Workflow Works
+## Default Workflow
 
-The **Review-Driven** track is our recommended standard. It ensures that humans remain in control of the architecture while Jules handles the implementation.
+The default workflow is **Review-Driven**:
 
-1. **Issue**: A human maintainer defines a scoped task.
-2. **Task**: Jules plans and implements the change.
-3. **Pull Request**: Jules opens a PR linked to the issue.
-4. **CI**: Automated checks validate the change.
-5. **Review**: A human maintainer reviews the code and requests changes if needed.
-6. **Merge**: The human maintainer makes the final decision to merge.
+```text
+Issue → Jules task → Pull request → CI → Human review → Merge
+```
+
+The maintainer stays responsible for scope, architecture, validation, and the final merge decision. Jules assists with implementation and documentation work through the GitHub workflow.
 
 ---
 
 ## What This Repo Includes
 
-- **Scoped Issue Templates**: Pre-configured for Jules tasks and experiments.
-- **PR Templates**: Standardized format with validation checklists.
-- **Workflow Levels**: From human-led tasks to experimental autonomy.
-- **Reference Examples**: Real-world issues and maintainer review examples.
-- **CI Validation**: Lightweight checks for Markdown and YAML hygiene.
-- **Reusable Prompts**: Templates for handoffs and status reporting.
+- **AGENTS.md** — repository rules for Jules-assisted work
+- **Issue templates** — scoped task and workflow experiment templates
+- **PR template** — linked issue, validation, and review expectations
+- **CI example** — lightweight checks for docs and starter kit structure
+- **Prompts** — issue handoff and maintainer report prompts
+- **Examples** — reusable issue and PR review examples
+- **Operations guides** — one-task-at-a-time, branch protection, labels, and triage
+- **Case studies** — one real applied case study and one planned English-only case study
+
+---
+
+## Key Guides
+
+- [Quickstart](./docs/quickstart.md)
+- [One Jules Task at a Time](./docs/operations/one-jules-task-at-a-time.md)
+- [Branch Protection and CI Gates](./docs/operations/branch-protection-and-ci-gates.md)
+- [Labels and Triage](./docs/operations/labels-and-triage.md)
+- [Project Readiness](./docs/meta/project-readiness.md)
+- [Documentation Audit](./docs/meta/documentation-audit.md)
 
 ---
 
 ## Case Studies
 
-- **[Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)** — A hardware/software capstone project using the Jules workflow.
-- **[Case Study B: md-link-linter](./docs/case-studies/english-only-project.md)** — (Planned) A minimalist Markdown link checker built with a CI-first approach.
+- **[Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)** — a real hardware/software capstone project using the Jules workflow.
+- **[Case Study B: English-Only Project Brief](./docs/case-studies/english-only-project.md)** — a planned small open-source project for showing the same workflow to a global audience.
 
 ---
 
-## Safety & Ownership
+## Safety and Ownership
 
-- **Human-Led**: A human decides the direction and owns the architecture.
-- **Jules as an Agent**: Jules is an AI coding agent, not a human contributor.
-- **CI Gates**: Every merge should be gated by automated checks.
-- **Sandbox for Experiments**: Full Vibe Coding must stay in sandbox environments.
+Stable guidance:
+
+```text
+Human decides direction.
+Human owns architecture.
+Human reviews final changes.
+CI gates every merge.
+Jules is an AI coding agent, not a human contributor.
+```
+
+Experimental guidance:
+
+```text
+Autonomous workflows belong in sandbox repos or protected branches.
+Auto-merge experiments require strict CI and branch protection.
+Evaluator-driven experiments need measurable tests or benchmarks.
+```
+
+---
+
+## Repository Structure
+
+```text
+.
+├── AGENTS.md
+├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   ├── PULL_REQUEST_TEMPLATE.md
+│   └── workflows/
+├── docs/
+│   ├── quickstart.md
+│   ├── case-studies/
+│   ├── experiments/
+│   ├── meta/
+│   ├── operations/
+│   └── workflows/
+├── examples/
+│   ├── issues/
+│   └── pr-reviews/
+└── prompts/
+```
 
 ---
 


### PR DESCRIPTION
Restructured the repository's entry points (README.md and README.ko.md) to be more scannable and oriented around four clear workflow tracks. This change targets students, teachers, and first-time GitHub users by providing a clearer path to adoption while maintaining the core message of process over final code. Review-Driven is set as the default recommended track, and Full Vibe Coding is marked as experimental. All changes were verified with local CI scripts and reviewed for consistency.

Fixes #59

---
*PR created automatically by Jules for task [15251849425254006007](https://jules.google.com/task/15251849425254006007) started by @hkimw*