### PR TITLE
Add non-Mermaid visual assets for README onboarding

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -9,15 +9,7 @@
 
 이 저장소는 AI-assisted work가 읽을 수 있는 engineering history를 남기도록 돕습니다.
 
-```mermaid
-graph LR
-    Issue --> Task[Jules task]
-    Task --> PR[Pull request]
-    PR --> CI
-    CI --> Review[Human review]
-    Review --> Merge
-    Review -.->|Request changes| Task
-```
+![Workflow Overview](./docs/assets/workflow-overview.svg)
 
 단순한 prompt 모음이 아니라 template, example, review checklist, CI gate, case study를 포함한 reusable workflow kit입니다.
 
@@ -44,6 +36,8 @@ graph LR
 ---
 
 ## Start Here
+
+![Getting Started Flow](./docs/assets/getting-started-flow.svg)
 
 - **[Quickstart 가이드](./docs/quickstart.md)** — 단계별 온보딩
 - **[운영 가이드](./docs/operations/one-jules-task-at-a-time.md)** — 안전한 태스크 순차 실행
@@ -97,6 +91,8 @@ Merge 전에 다음을 확인합니다.
 ## Workflow Levels
 
 이 starter kit은 안정적인 maintainer workflow와 실험적 automation을 분리합니다.
+
+![Four Tracks Overview](./docs/assets/four-tracks-overview.svg)
 
 | Level | Workflow | Human role | Status |
 | --- | --- | --- | --- |
@@ -204,6 +200,8 @@ Evaluator-driven evolution must use measurable tests or benchmarks.
 대부분의 AI coding demo는 완성된 코드만 보여줍니다.
 
 이 프로젝트는 과정을 보여줍니다.
+
+![Workflow Overview](./docs/assets/workflow-overview.svg)
 
 ```text
 Issue.

--- a/README.md
+++ b/README.md
@@ -9,15 +9,7 @@
 
 It is built for maintainers who want AI-assisted work to leave a clean engineering history:
 
-```mermaid
-graph LR
-    Issue --> Task[Jules task]
-    Task --> PR[Pull request]
-    PR --> CI
-    CI --> Review[Human review]
-    Review --> Merge
-    Review -.->|Request changes| Task
-```
+![Workflow Overview](./docs/assets/workflow-overview.svg)
 
 This is not a prompt dump. It is a reusable workflow kit with templates, examples, review checklists, CI gates, and case studies.
 
@@ -44,6 +36,8 @@ Not:
 ---
 
 ## Start Here
+
+![Getting Started Flow](./docs/assets/getting-started-flow.svg)
 
 - **[Quickstart Guide](./docs/quickstart.md)** — step-by-step onboarding
 - **[Operations Guide](./docs/operations/one-jules-task-at-a-time.md)** — sequencing tasks safely
@@ -97,6 +91,8 @@ Before merging, check:
 ## Workflow Levels
 
 This starter kit separates stable maintainer workflows from experimental automation.
+
+![Four Tracks Overview](./docs/assets/four-tracks-overview.svg)
 
 | Level | Workflow | Human role | Status |
 | --- | --- | --- | --- |
@@ -204,6 +200,8 @@ Evaluator-driven evolution must use measurable tests or benchmarks.
 Most AI coding demos show only the final code.
 
 This project shows the process:
+
+![Workflow Overview](./docs/assets/workflow-overview.svg)
 
 ```text
 Issue.

--- a/docs/assets/four-tracks-overview.svg
+++ b/docs/assets/four-tracks-overview.svg
@@ -1,0 +1,47 @@
+<svg width="600" height="220" viewBox="0 0 600 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .title { font-size: 14px; font-weight: 600; }
+    .desc { font-size: 11px; }
+    .node { stroke-width: 1.5; }
+
+    @media (prefers-color-scheme: dark) {
+      .title { fill: #adbac7; }
+      .desc { fill: #768390; }
+      .node { fill: #22272e; stroke: #444c56; }
+    }
+    @media (prefers-color-scheme: light) {
+      .title { fill: #24292f; }
+      .desc { fill: #57606a; }
+      .node { fill: #ffffff; stroke: #d0d7de; }
+    }
+  </style>
+
+  <!-- Track 1: Review-Driven -->
+  <rect x="10" y="10" width="280" height="90" rx="6" class="node" />
+  <text x="30" y="35" class="text title">Track 1: Review-Driven (Default)</text>
+  <text x="30" y="55" class="text desc">Human-led workflow. Jules as a contributor.</text>
+  <text x="30" y="70" class="text desc">Issue → Jules PR → Human Review → Merge</text>
+  <text x="30" y="85" class="text desc">Recommended for most production tasks.</text>
+
+  <!-- Track 2: GitHub-Native Collaboration -->
+  <rect x="310" y="10" width="280" height="90" rx="6" class="node" />
+  <text x="330" y="35" class="text title">Track 2: GitHub-Native Collab</text>
+  <text x="330" y="55" class="text desc">Focused on learning GitHub conventions.</text>
+  <text x="330" y="70" class="text desc">Labels, Milestones, and Discussion loops.</text>
+  <text x="330" y="85" class="text desc">Ideal for teams and students.</text>
+
+  <!-- Track 3: Half Vibe Coding -->
+  <rect x="10" y="120" width="280" height="90" rx="6" class="node" />
+  <text x="30" y="145" class="text title">Track 3: Half Vibe Coding</text>
+  <text x="30" y="165" class="text desc">Advanced mode with lower touch.</text>
+  <text x="30" y="180" class="text desc">Strict CI + Jules handles implementation.</text>
+  <text x="30" y="195" class="text desc">Requires trust and solid test coverage.</text>
+
+  <!-- Track 4: Full Vibe Coding -->
+  <rect x="310" y="120" width="280" height="90" rx="6" class="node" />
+  <text x="330" y="145" class="text title">Track 4: Full Vibe Coding</text>
+  <text x="330" y="165" class="text desc">Experimental sandbox automation.</text>
+  <text x="330" y="180" class="text desc">No-human loops and evaluator-driven.</text>
+  <text x="330" y="195" class="text desc">Strictly for sandboxes and experiments.</text>
+</svg>

--- a/docs/assets/getting-started-flow.svg
+++ b/docs/assets/getting-started-flow.svg
@@ -1,0 +1,67 @@
+<svg width="600" height="150" viewBox="0 0 600 150" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; font-size: 12px; }
+    .step-circle { stroke-width: 2; }
+    .step-text { font-weight: 600; font-size: 14px; }
+    .arrow { stroke-width: 1.5; fill: none; }
+
+    @media (prefers-color-scheme: dark) {
+      .text { fill: #adbac7; }
+      .step-text { fill: #adbac7; }
+      .step-circle { fill: #22272e; stroke: #444c56; }
+      .arrow { stroke: #444c56; }
+      .arrow-head { fill: #444c56; }
+    }
+    @media (prefers-color-scheme: light) {
+      .text { fill: #24292f; }
+      .step-text { fill: #24292f; }
+      .step-circle { fill: #ffffff; stroke: #d0d7de; }
+      .arrow { stroke: #d0d7de; }
+      .arrow-head { fill: #d0d7de; }
+    }
+  </style>
+
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" class="arrow-head" />
+    </marker>
+  </defs>
+
+  <!-- Step 1 -->
+  <circle cx="50" cy="50" r="25" class="step-circle" />
+  <text x="50" y="55" text-anchor="middle" class="step-text">1</text>
+  <text x="50" y="100" text-anchor="middle" class="text">Copy</text>
+  <text x="50" y="115" text-anchor="middle" class="text">Starter Kit</text>
+
+  <line x1="80" y1="50" x2="130" y2="50" class="arrow" marker-end="url(#arrowhead)" />
+
+  <!-- Step 2 -->
+  <circle cx="170" cy="50" r="25" class="step-circle" />
+  <text x="170" y="55" text-anchor="middle" class="step-text">2</text>
+  <text x="170" y="100" text-anchor="middle" class="text">Open</text>
+  <text x="170" y="115" text-anchor="middle" class="text">Small Issue</text>
+
+  <line x1="200" y1="50" x2="250" y2="50" class="arrow" marker-end="url(#arrowhead)" />
+
+  <!-- Step 3 -->
+  <circle cx="290" cy="50" r="25" class="step-circle" />
+  <text x="290" y="55" text-anchor="middle" class="step-text">3</text>
+  <text x="290" y="100" text-anchor="middle" class="text">Trigger</text>
+  <text x="290" y="115" text-anchor="middle" class="text">Jules Task</text>
+
+  <line x1="320" y1="50" x2="370" y2="50" class="arrow" marker-end="url(#arrowhead)" />
+
+  <!-- Step 4 -->
+  <circle cx="410" cy="50" r="25" class="step-circle" />
+  <text x="410" y="55" text-anchor="middle" class="step-text">4</text>
+  <text x="410" y="100" text-anchor="middle" class="text">Review</text>
+  <text x="410" y="115" text-anchor="middle" class="text">Jules PR</text>
+
+  <line x1="440" y1="50" x2="490" y2="50" class="arrow" marker-end="url(#arrowhead)" />
+
+  <!-- Step 5 -->
+  <circle cx="530" cy="50" r="25" class="step-circle" />
+  <text x="530" y="55" text-anchor="middle" class="step-text">5</text>
+  <text x="530" y="100" text-anchor="middle" class="text">Merge</text>
+  <text x="530" y="115" text-anchor="middle" class="text">to main</text>
+</svg>

--- a/docs/assets/workflow-overview.svg
+++ b/docs/assets/workflow-overview.svg
@@ -1,0 +1,56 @@
+<svg width="850" height="150" viewBox="0 0 850 150" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; font-size: 13px; }
+    .node { stroke-width: 1.5; }
+    .arrow { stroke-width: 1.5; fill: none; }
+
+    @media (prefers-color-scheme: dark) {
+      .text { fill: #adbac7; }
+      .node { fill: #22272e; stroke: #444c56; }
+      .arrow { stroke: #444c56; }
+      .arrow-head { fill: #444c56; }
+    }
+    @media (prefers-color-scheme: light) {
+      .text { fill: #24292f; }
+      .node { fill: #ffffff; stroke: #d0d7de; }
+      .arrow { stroke: #d0d7de; }
+      .arrow-head { fill: #d0d7de; }
+    }
+  </style>
+
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" class="arrow-head" />
+    </marker>
+  </defs>
+
+  <!-- Nodes -->
+  <rect x="10" y="55" width="90" height="40" rx="4" class="node" />
+  <text x="55" y="80" text-anchor="middle" class="text">Issue</text>
+
+  <rect x="150" y="55" width="90" height="40" rx="4" class="node" />
+  <text x="195" y="80" text-anchor="middle" class="text">Jules Task</text>
+
+  <rect x="290" y="55" width="100" height="40" rx="4" class="node" />
+  <text x="340" y="80" text-anchor="middle" class="text">Pull Request</text>
+
+  <rect x="440" y="55" width="90" height="40" rx="4" class="node" />
+  <text x="485" y="80" text-anchor="middle" class="text">CI Check</text>
+
+  <rect x="580" y="55" width="110" height="40" rx="4" class="node" />
+  <text x="635" y="80" text-anchor="middle" class="text">Human Review</text>
+
+  <rect x="740" y="55" width="80" height="40" rx="4" class="node" />
+  <text x="780" y="80" text-anchor="middle" class="text">Merge</text>
+
+  <!-- Arrows -->
+  <line x1="100" y1="75" x2="150" y2="75" class="arrow" marker-end="url(#arrowhead)" />
+  <line x1="240" y1="75" x2="290" y2="75" class="arrow" marker-end="url(#arrowhead)" />
+  <line x1="390" y1="75" x2="440" y2="75" class="arrow" marker-end="url(#arrowhead)" />
+  <line x1="530" y1="75" x2="580" y2="75" class="arrow" marker-end="url(#arrowhead)" />
+  <line x1="690" y1="75" x2="740" y2="75" class="arrow" marker-end="url(#arrowhead)" />
+
+  <!-- Feedback Loop -->
+  <path d="M635 55 V30 H195 V55" stroke-dasharray="4" class="arrow" marker-end="url(#arrowhead)" />
+  <text x="415" y="25" text-anchor="middle" class="text" style="font-size: 11px;">Request Changes</text>
+</svg>


### PR DESCRIPTION
This PR replaces Mermaid diagrams in the README files with static SVG assets. 

Key changes:
- Created `docs/assets/workflow-overview.svg` illustrating the core feedback loop.
- Created `docs/assets/four-tracks-overview.svg` illustrating the four workflow tracks.
- Created `docs/assets/getting-started-flow.svg` illustrating the onboarding steps.
- Updated `README.md` and `README.ko.md` to include these visuals.
- Removed all Mermaid diagram blocks from the READMEs.

The SVGs are designed to work in both light and dark modes using internal CSS media queries. No external dependencies or animated graphics were added.

Fixes #63

---
*PR created automatically by Jules for task [10020562244308864889](https://jules.google.com/task/10020562244308864889) started by @hkimw*