### PR TITLE
Restructure README around four workflow tracks

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,71 +1,49 @@
 # AI Coding Workflow Starter Kit for Jules
 
-[English](./README.md) · [한국어](./README.ko.md) · [프로젝트 준비 상태](./docs/meta/project-readiness.md) · [출시 체크리스트](./docs/meta/release-checklist.md) · [기여하기](./CONTRIBUTING.md) · [행동 강령](./CODE_OF_CONDUCT.md) · [보안](./SECURITY.md)
+[English](./README.md) · [한국어](./README.ko.md) · [Quickstart](./docs/quickstart.md) · [프로젝트 준비 상태](./docs/meta/project-readiness.md) · [출시 체크리스트](./docs/meta/release-checklist.md) · [기여하기](./CONTRIBUTING.md) · [보안](./SECURITY.md)
 
 > 대부분의 AI 코딩 데모는 완성된 코드만 보여줍니다.  
 > 이 프로젝트는 그 과정 자체를 보여줍니다.
 
-**AI Coding Workflow Starter Kit for Jules**는 Jules를 GitHub Issue, Pull Request, Review, CI, case study, controlled automation 안에서 운영하기 위한 GitHub-native starter kit입니다.
+**AI Coding Workflow Starter Kit for Jules**는 Jules를 GitHub Issue, Pull Request, Review, CI, case study, controlled workflow experiment 안에서 운영하기 위한 GitHub-native playbook입니다.
 
-이 저장소는 AI-assisted work가 읽을 수 있는 engineering history를 남기도록 돕습니다.
+이 저장소는 학생, 교사, GitHub를 처음 쓰는 maintainer, 작은 팀이 AI-assisted coding work를 읽을 수 있는 engineering history로 남기도록 돕습니다.
 
-```mermaid
-graph LR
-    Issue --> Task[Jules task]
-    Task --> PR[Pull request]
-    PR --> CI
-    CI --> Review[Human review]
-    Review --> Merge
-    Review -.->|Request changes| Task
+단순한 prompt 모음이 아닙니다. 일반적인 GitHub practice 안에서 AI-assisted work를 운영하기 위한 reusable starter kit입니다.
+
+---
+
+## 트랙 선택하기
+
+원하는 인간 개입 수준에 맞는 workflow를 고르세요.
+
+| 트랙 | 적합한 상황 | 인간 개입 | 상태 |
+| --- | --- | --- | --- |
+| **[Review-Driven](./docs/tracks/review-driven.md)** | 실제 프로젝트, 수업, starter repo | 중간 | **기본 권장** |
+| **[GitHub-Native Collaboration](./docs/tracks/github-native-collaboration.md)** | Issue, PR, review, CI, label, branch protection 학습 | 중간 | 학습용 권장 |
+| **[Half Vibe Coding](./docs/tracks/half-vibe-coding.md)** | maintainer가 방향을 주고 Jules가 checkpoint 사이를 실행 | 낮음 | 고급 |
+| **[Full Vibe Coding](./docs/tracks/full-vibe-coding.md)** | sandbox experiment와 workflow research | 최소 | 실험 전용 |
+
+대부분의 독자에게 추천하는 순서:
+
+```text
+Review-Driven으로 시작합니다.
+GitHub 협업을 가르치거나 배울 때 GitHub-Native Collaboration을 사용합니다.
+CI와 review rule이 잡힌 뒤에 Half Vibe Coding을 시도합니다.
+Full Vibe Coding은 sandbox repo 또는 protected branch에서만 다룹니다.
 ```
 
-단순한 prompt 모음이 아니라 template, example, review checklist, CI gate, case study를 포함한 reusable workflow kit입니다.
-
 ---
 
-## What You Get
+## 시작하기
 
-- Jules task를 위한 scoped GitHub Issue template
-- linked issue와 validation notes를 요구하는 PR template
-- approve/request changes용 maintainer review example
-- Markdown, YAML, required starter kit file을 확인하는 lightweight CI
-- human-led workflow부터 sandbox-only automation experiment까지 나눈 workflow levels
-- issue handoff와 daily maintainer report용 prompt
-- 실제 프로젝트에 workflow를 적용한 case study
+1. **[Quickstart Guide](./docs/quickstart.md)**를 읽습니다.
+2. starter file을 자신의 repository에 복사합니다.
+3. 작은 GitHub Issue를 엽니다.
+4. Jules가 focused pull request를 만들게 합니다.
+5. PR을 review하고, CI를 확인한 뒤, maintainer가 만족할 때만 merge합니다.
 
-핵심 메시지는 단순합니다.
-
-> Human maintainer가 AI coding agent를 일반적인 GitHub engineering practice 안에서 리드한다.
-
-아래 메시지가 아닙니다.
-
-> AI가 프로젝트 전체를 혼자 만들었다.
-
----
-
-## Start Here
-
-- **[Quickstart 가이드](./docs/quickstart.md)** — 단계별 온보딩
-- **[운영 가이드](./docs/operations/one-jules-task-at-a-time.md)** — 안전한 태스크 순차 실행
-- **[브랜치 보호 가이드](./docs/operations/branch-protection-and-ci-gates.md)** — CI 게이트와 `main` 보호
-- **[라벨 및 트리아지 가이드](./docs/operations/labels-and-triage.md)** — AI 태스크 정리
-
----
-
-## Workflow Tracks
-
-프로젝트의 성숙도와 팀 규모에 맞는 트랙을 선택하세요.
-
-- **[GitHub-Native Collaboration](./docs/tracks/github-native-collaboration.md)** — Jules와 함께 실제 GitHub 협업을 배우기에 최적
-- **[Review-Driven](./docs/tracks/review-driven.md)** — 프로덕션을 위한 **권장 기본** 워크플로우
-- **[Half Vibe Coding](./docs/tracks/half-vibe-coding.md)** — 주기적인 사람의 개입이 포함된 고급 저접촉(low-touch) 워크플로우
-- **[Full Vibe Coding](./docs/tracks/full-vibe-coding.md)** — 프로덕션용이 아닌 **실험적** 샌드박스 워크플로우
-
----
-
-### 1. Starter Kit 파일 복사하기
-
-자기 repository에 먼저 아래 파일들을 복사합니다.
+먼저 복사할 starter file:
 
 ```text
 AGENTS.md
@@ -76,121 +54,53 @@ prompts/
 examples/
 ```
 
-### 2. 작은 Issue 하나 열기
+---
 
-좋은 issue:
+## 기본 워크플로우
+
+기본 workflow는 **Review-Driven**입니다.
 
 ```text
-Add a PR template that requires a linked issue, validation steps, and a reviewer checklist.
+Issue → Jules task → Pull request → CI → Human review → Merge
 ```
 
-나쁜 issue:
-
-```text
-Improve the project.
-```
-
-### 3. Issue를 Jules에게 넘기기
-
-Issue를 source of truth로 사용합니다. Jules는 issue를 대체하는 것이 아니라 focused PR을 만들어야 합니다.
-
-### 4. Merge 전 Review하기
-
-Merge 전에 다음을 확인합니다.
-
-- PR이 linked issue를 해결하는가?
-- scope가 통제되어 있는가?
-- 관련 없는 파일이 바뀌지 않았는가?
-- tests 또는 validation steps가 포함되어 있는가?
-- CI가 통과하는가?
-- 나중에 다른 개발자가 이 history를 이해할 수 있는가?
+Maintainer는 scope, architecture, validation, final merge decision을 계속 책임집니다. Jules는 GitHub workflow 안에서 implementation과 documentation 작업을 보조합니다.
 
 ---
 
-## Workflow Levels
+## 포함된 내용
 
-이 starter kit은 안정적인 maintainer workflow와 실험적 automation을 분리합니다.
-
-| Level | Workflow | Human role | Status |
-| --- | --- | --- | --- |
-| 1 | Human-led Jules workflow | issue 작성, PR review, merge | recommended default |
-| 2 | Semi-autonomous Jules workflow | issue 작성, final PR review | practical advanced mode |
-| 3 | Human issue only | issue만 작성, Jules가 implementation/PR update | advanced with strict CI |
-| 4 | Daily agentic maintainer loop | daily report를 보고 방향 조정 | advanced planning loop |
-| 5 | No-human sandbox workflow | 관찰 또는 audit만 수행 | experiment only |
-| 6 | Jules + evaluator-driven evolution | objective/evaluator 정의, 결과 review | experiment only |
-
-기본값은 Level 1입니다. Level 5와 6은 sandbox 또는 protected experiment branch에서만 다룹니다.
+- **AGENTS.md** — Jules-assisted work를 위한 repository rule
+- **Issue templates** — scoped task와 workflow experiment template
+- **PR template** — linked issue, validation, review expectation
+- **CI example** — docs와 starter kit 구조를 확인하는 lightweight check
+- **Prompts** — issue handoff와 maintainer report prompt
+- **Examples** — reusable issue와 PR review example
+- **Operations guides** — one-task-at-a-time, branch protection, labels, triage
+- **Workflow tracks** — review-driven부터 sandbox experiment까지 4가지 Jules workflow
+- **Case studies** — 실제 적용 사례 1개와 planned English-only case study 1개
 
 ---
 
-## Repository Structure
+## 주요 가이드
 
-```text
-.
-├── README.md
-├── README.ko.md
-├── AGENTS.md
-├── CONTRIBUTING.md
-├── CODE_OF_CONDUCT.md
-├── SECURITY.md
-├── LICENSE
-├── .github/
-│   ├── ISSUE_TEMPLATE/
-│   │   ├── jules_task.yml
-│   │   └── workflow_experiment.yml
-│   ├── workflows/
-│   │   └── docs-and-templates.yml
-│   └── PULL_REQUEST_TEMPLATE.md
-├── examples/
-│   ├── issues/
-│   └── pr-reviews/
-├── docs/
-│   ├── quickstart.md
-│   ├── meta/
-│   │   ├── project-readiness.md
-│   │   ├── release-checklist.md
-│   │   └── documentation-audit.md
-│   ├── operations/
-│   │   ├── one-jules-task-at-a-time.md
-│   │   ├── branch-protection-and-ci-gates.md
-│   │   └── labels-and-triage.md
-│   ├── workflows/
-│   │   └── workflow-levels.md
-│   ├── experiments/
-│   │   ├── no-human-only-jules-workflow.md
-│   │   └── jules-alpha-evolve.md
-│   └── case-studies/
-│       ├── digital-logic-circuit.md
-│       └── english-only-project.md
-└── prompts/
-    ├── issue-to-jules-task.md
-    └── daily-maintainer-report.md
-```
+- [Quickstart](./docs/quickstart.md)
+- [One Jules Task at a Time](./docs/operations/one-jules-task-at-a-time.md)
+- [Branch Protection and CI Gates](./docs/operations/branch-protection-and-ci-gates.md)
+- [Labels and Triage](./docs/operations/labels-and-triage.md)
+- [Project Readiness](./docs/meta/project-readiness.md)
+- [Documentation Audit](./docs/meta/documentation-audit.md)
 
 ---
 
-## Case Studies
+## 케이스 스터디
 
-### [Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)
-
-Repository: <https://github.com/hkimw-underground/digital-logic-circuit>
-
-실제 hardware/software capstone case study입니다. planning과 implementation을 GitHub Issues, PRs, human review, Jules-assisted implementation 중심으로 옮기는 사례입니다.
-
-Architecture, hardware constraints, scope, review, final merge decision은 maintainer가 책임집니다.
-
-### [Case Study B: English-Only Open Source Project](./docs/case-studies/english-only-project.md)
-
-Status: planned (`md-link-linter`).
-
-글로벌 독자를 위한 예정된 순수 영어 case study입니다. 학교/capstone 맥락 밖에서도 minimalist Markdown link checker 제작 과정을 통해 small issues, focused Jules PRs, CI-first development, readable review comments가 재사용 가능하다는 것을 보여주는 목적입니다.
+- **[Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)** — Jules workflow를 적용한 실제 hardware/software capstone project.
+- **[Case Study B: English-Only Project Brief](./docs/case-studies/english-only-project.md)** — 글로벌 독자를 위한 작은 open-source project 계획 문서.
 
 ---
 
-## Safety Position
-
-이 저장소는 automation을 다루지만, automation 자체를 기본 목표로 삼지 않습니다.
+## 안전 및 책임
 
 Stable guidance:
 
@@ -199,39 +109,44 @@ Human decides direction.
 Human owns architecture.
 Human reviews final changes.
 CI gates every merge.
-Jules is never presented as a human contributor.
+Jules is an AI coding agent, not a human contributor.
 ```
 
 Experimental guidance:
 
 ```text
-No-human workflows must run in sandbox repos or protected branches.
-Auto-merge requires strict CI and branch protection.
-Evaluator-driven evolution must use measurable tests or benchmarks.
+Autonomous workflows belong in sandbox repos or protected branches.
+Auto-merge experiments require strict CI and branch protection.
+Evaluator-driven experiments need measurable tests or benchmarks.
 ```
 
 ---
 
-## Why This Exists
-
-대부분의 AI coding demo는 완성된 코드만 보여줍니다.
-
-이 프로젝트는 과정을 보여줍니다.
+## Repository Structure
 
 ```text
-Issue.
-Prompt.
-Plan.
-Pull request.
-Review.
-CI.
-History.
+.
+├── AGENTS.md
+├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   ├── PULL_REQUEST_TEMPLATE.md
+│   └── workflows/
+├── docs/
+│   ├── quickstart.md
+│   ├── case-studies/
+│   ├── experiments/
+│   ├── meta/
+│   ├── operations/
+│   ├── tracks/
+│   └── workflows/
+├── examples/
+│   ├── issues/
+│   └── pr-reviews/
+└── prompts/
 ```
-
-진짜 AI-assisted engineering은 여기서 일어납니다.
 
 ---
 
 ## 라이선스
 
-이 프로젝트는 [MIT 라이선스](./LICENSE)를 따릅니다.
+이 프로젝트는 [MIT License](./LICENSE)를 따릅니다.

--- a/README.md
+++ b/README.md
@@ -1,71 +1,49 @@
 # AI Coding Workflow Starter Kit for Jules
 
-[English](./README.md) · [한국어](./README.ko.md) · [Project Readiness](./docs/meta/project-readiness.md) · [Launch Checklist](./docs/meta/release-checklist.md) · [Contributing](./CONTRIBUTING.md) · [Code of Conduct](./CODE_OF_CONDUCT.md) · [Security](./SECURITY.md)
+[English](./README.md) · [한국어](./README.ko.md) · [Quickstart](./docs/quickstart.md) · [Project Readiness](./docs/meta/project-readiness.md) · [Launch Checklist](./docs/meta/release-checklist.md) · [Contributing](./CONTRIBUTING.md) · [Security](./SECURITY.md)
 
 > Most AI coding demos show only the final code.  
 > This project shows the process.
 
-**AI Coding Workflow Starter Kit for Jules** is a GitHub-native starter kit for leading Jules through issues, pull requests, reviews, CI, case studies, and controlled automation.
+**AI Coding Workflow Starter Kit for Jules** is a GitHub-native playbook for working with Jules through issues, pull requests, reviews, CI, case studies, and controlled workflow experiments.
 
-It is built for maintainers who want AI-assisted work to leave a clean engineering history:
+It is built for students, teachers, first-time maintainers, and small teams who want AI-assisted coding work to leave a readable engineering history.
 
-```mermaid
-graph LR
-    Issue --> Task[Jules task]
-    Task --> PR[Pull request]
-    PR --> CI
-    CI --> Review[Human review]
-    Review --> Merge
-    Review -.->|Request changes| Task
-```
-
-This is not a prompt dump. It is a reusable workflow kit with templates, examples, review checklists, CI gates, and case studies.
+This is not a prompt dump. It is a reusable starter kit for running AI-assisted work inside normal GitHub practice.
 
 ---
 
-## What You Get
+## Choose Your Track
 
-- scoped GitHub Issue templates for Jules tasks
-- PR templates that require linked issues and validation notes
-- maintainer review examples for approving or requesting changes
-- lightweight CI checks for Markdown, YAML, and required starter kit files
-- workflow levels from human-led work to sandbox-only automation experiments
-- prompts for issue handoff and daily maintainer reports
-- case studies showing how the workflow applies to real projects
+Pick the workflow that matches how much human involvement you want.
 
-The core idea is simple:
+| Track | Best for | Human involvement | Status |
+| --- | --- | --- | --- |
+| **[Review-Driven](./docs/tracks/review-driven.md)** | Real projects, classrooms, starter repos | Medium | **Recommended default** |
+| **[GitHub-Native Collaboration](./docs/tracks/github-native-collaboration.md)** | Learning Issues, PRs, reviews, CI, labels, and branch protection | Medium | Recommended for learning |
+| **[Half Vibe Coding](./docs/tracks/half-vibe-coding.md)** | Direction from a maintainer, execution by Jules between checkpoints | Low | Advanced |
+| **[Full Vibe Coding](./docs/tracks/full-vibe-coding.md)** | Sandbox experiments and workflow research | Minimal | Experimental only |
 
-> A human maintainer leads an AI coding agent through normal GitHub engineering practice.
+Recommended path for most readers:
 
-Not:
-
-> AI built the whole project by itself.
+```text
+Start with Review-Driven.
+Use GitHub-Native Collaboration when teaching or learning teamwork.
+Try Half Vibe Coding only after CI and review rules are in place.
+Keep Full Vibe Coding in sandbox repositories or protected branches.
+```
 
 ---
 
 ## Start Here
 
-- **[Quickstart Guide](./docs/quickstart.md)** — step-by-step onboarding
-- **[Operations Guide](./docs/operations/one-jules-task-at-a-time.md)** — sequencing tasks safely
-- **[Branch Protection Guide](./docs/operations/branch-protection-and-ci-gates.md)** — CI gates and protecting `main`
-- **[Labels and Triage Guide](./docs/operations/labels-and-triage.md)** — organizing AI tasks
+1. Read the **[Quickstart Guide](./docs/quickstart.md)**.
+2. Copy the starter files into your repository.
+3. Open a small GitHub Issue.
+4. Let Jules create a focused pull request.
+5. Review the PR, check CI, and merge only when the maintainer is satisfied.
 
----
-
-## Workflow Tracks
-
-Choose the track that fits your project maturity and team size:
-
-- **[GitHub-Native Collaboration](./docs/tracks/github-native-collaboration.md)** — best for learning real GitHub teamwork with Jules
-- **[Review-Driven](./docs/tracks/review-driven.md)** — **recommended default** workflow for production
-- **[Half Vibe Coding](./docs/tracks/half-vibe-coding.md)** — advanced, low-touch workflow with periodic human direction
-- **[Full Vibe Coding](./docs/tracks/full-vibe-coding.md)** — **experimental** sandbox workflow, not for production
-
----
-
-### 1. Copy the Starter Kit Files
-
-Start with these files in your own repository:
+Starter files to copy first:
 
 ```text
 AGENTS.md
@@ -76,121 +54,53 @@ prompts/
 examples/
 ```
 
-### 2. Open a Small Issue
+---
 
-Good issue:
+## Default Workflow
 
-```text
-Add a PR template that requires a linked issue, validation steps, and a reviewer checklist.
-```
-
-Bad issue:
+The default workflow is **Review-Driven**:
 
 ```text
-Improve the project.
+Issue → Jules task → Pull request → CI → Human review → Merge
 ```
 
-### 3. Hand the Issue to Jules
-
-Use the issue as the source of truth. Jules should produce a focused PR, not replace the issue.
-
-### 4. Review Before Merge
-
-Before merging, check:
-
-- Does the PR solve the linked issue?
-- Is the scope controlled?
-- Are unrelated files changed?
-- Are tests or validation steps included?
-- Does CI pass?
-- Would another developer understand this history later?
+The maintainer stays responsible for scope, architecture, validation, and the final merge decision. Jules assists with implementation and documentation work through the GitHub workflow.
 
 ---
 
-## Workflow Levels
+## What This Repo Includes
 
-This starter kit separates stable maintainer workflows from experimental automation.
-
-| Level | Workflow | Human role | Status |
-| --- | --- | --- | --- |
-| 1 | Human-led Jules workflow | creates issue, reviews PR, merges | recommended default |
-| 2 | Semi-autonomous Jules workflow | creates issue, reviews final PR | practical advanced mode |
-| 3 | Human issue only | writes issue; Jules handles implementation and PR updates | advanced with strict CI |
-| 4 | Daily agentic maintainer loop | steers direction from daily reports | advanced planning loop |
-| 5 | No-human sandbox workflow | observes or audits only | experiment only |
-| 6 | Jules + evaluator-driven evolution | defines objective/evaluator and reviews result | experiment only |
-
-The default workflow is Level 1. Levels 5 and 6 belong in sandboxes, not unprotected production branches.
+- **AGENTS.md** — repository rules for Jules-assisted work
+- **Issue templates** — scoped task and workflow experiment templates
+- **PR template** — linked issue, validation, and review expectations
+- **CI example** — lightweight checks for docs and starter kit structure
+- **Prompts** — issue handoff and maintainer report prompts
+- **Examples** — reusable issue and PR review examples
+- **Operations guides** — one-task-at-a-time, branch protection, labels, and triage
+- **Workflow tracks** — four ways to work with Jules, from review-driven to sandbox experiments
+- **Case studies** — one real applied case study and one planned English-only case study
 
 ---
 
-## Repository Structure
+## Key Guides
 
-```text
-.
-├── README.md
-├── README.ko.md
-├── AGENTS.md
-├── CONTRIBUTING.md
-├── CODE_OF_CONDUCT.md
-├── SECURITY.md
-├── LICENSE
-├── .github/
-│   ├── ISSUE_TEMPLATE/
-│   │   ├── jules_task.yml
-│   │   └── workflow_experiment.yml
-│   ├── workflows/
-│   │   └── docs-and-templates.yml
-│   └── PULL_REQUEST_TEMPLATE.md
-├── examples/
-│   ├── issues/
-│   └── pr-reviews/
-├── docs/
-│   ├── quickstart.md
-│   ├── meta/
-│   │   ├── project-readiness.md
-│   │   ├── release-checklist.md
-│   │   └── documentation-audit.md
-│   ├── operations/
-│   │   ├── one-jules-task-at-a-time.md
-│   │   ├── branch-protection-and-ci-gates.md
-│   │   └── labels-and-triage.md
-│   ├── workflows/
-│   │   └── workflow-levels.md
-│   ├── experiments/
-│   │   ├── no-human-only-jules-workflow.md
-│   │   └── jules-alpha-evolve.md
-│   └── case-studies/
-│       ├── digital-logic-circuit.md
-│       └── english-only-project.md
-└── prompts/
-    ├── issue-to-jules-task.md
-    └── daily-maintainer-report.md
-```
+- [Quickstart](./docs/quickstart.md)
+- [One Jules Task at a Time](./docs/operations/one-jules-task-at-a-time.md)
+- [Branch Protection and CI Gates](./docs/operations/branch-protection-and-ci-gates.md)
+- [Labels and Triage](./docs/operations/labels-and-triage.md)
+- [Project Readiness](./docs/meta/project-readiness.md)
+- [Documentation Audit](./docs/meta/documentation-audit.md)
 
 ---
 
 ## Case Studies
 
-### [Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)
-
-Repository: <https://github.com/hkimw-underground/digital-logic-circuit>
-
-A real hardware/software capstone case study showing how planning and implementation can move into GitHub Issues, PRs, human review, and Jules-assisted implementation.
-
-The maintainer owns architecture, hardware constraints, scope, review, and final merge decisions.
-
-### [Case Study B: English-Only Open Source Project](./docs/case-studies/english-only-project.md)
-
-Status: planned (`md-link-linter`).
-
-A planned English-only case study for a global audience. It will demonstrate the same workflow outside a school/capstone context by building a minimalist Markdown link checker: small issues, focused Jules PRs, CI-first development, and readable review comments.
+- **[Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)** — a real hardware/software capstone project using the Jules workflow.
+- **[Case Study B: English-Only Project Brief](./docs/case-studies/english-only-project.md)** — a planned small open-source project for showing the same workflow to a global audience.
 
 ---
 
-## Safety Position
-
-This repository supports automation, but it does not treat automation as the default goal.
+## Safety and Ownership
 
 Stable guidance:
 
@@ -199,36 +109,41 @@ Human decides direction.
 Human owns architecture.
 Human reviews final changes.
 CI gates every merge.
-Jules is never presented as a human contributor.
+Jules is an AI coding agent, not a human contributor.
 ```
 
 Experimental guidance:
 
 ```text
-No-human workflows must run in sandbox repos or protected branches.
-Auto-merge requires strict CI and branch protection.
-Evaluator-driven evolution must use measurable tests or benchmarks.
+Autonomous workflows belong in sandbox repos or protected branches.
+Auto-merge experiments require strict CI and branch protection.
+Evaluator-driven experiments need measurable tests or benchmarks.
 ```
 
 ---
 
-## Why This Exists
-
-Most AI coding demos show only the final code.
-
-This project shows the process:
+## Repository Structure
 
 ```text
-Issue.
-Prompt.
-Plan.
-Pull request.
-Review.
-CI.
-History.
+.
+├── AGENTS.md
+├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   ├── PULL_REQUEST_TEMPLATE.md
+│   └── workflows/
+├── docs/
+│   ├── quickstart.md
+│   ├── case-studies/
+│   ├── experiments/
+│   ├── meta/
+│   ├── operations/
+│   ├── tracks/
+│   └── workflows/
+├── examples/
+│   ├── issues/
+│   └── pr-reviews/
+└── prompts/
 ```
-
-That is where real AI-assisted engineering happens.
 
 ---
 


### PR DESCRIPTION
## Summary

Re-applies the README restructuring from the updated `main` branch after #62 landed.

## Changes

- Replaces the dense README opening with a clearer four-track entry point.
- Makes Review-Driven the recommended default track.
- Keeps GitHub-Native Collaboration as the learning track.
- Marks Half Vibe Coding as advanced and Full Vibe Coding as experimental.
- Removes Mermaid from the README files.
- Keeps the README focused on public-facing onboarding.
- Keeps README.md and README.ko.md aligned.

## Validation

- [x] Links are relative.
- [x] Jules is framed as an AI coding agent, not a human contributor.
- [x] Maintainer ownership remains explicit.
- [x] README first screen is more scannable.
- [ ] Docs CI passes.

Closes #59.