### PR TITLE
Add static README visuals for workflow onboarding

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -9,6 +9,8 @@
 
 이 저장소는 학생, 교사, GitHub를 처음 쓰는 maintainer, 작은 팀이 AI-assisted coding work를 읽을 수 있는 engineering history로 남기도록 돕습니다.
 
+![Workflow overview](./docs/assets/workflow-overview.svg)
+
 단순한 prompt 모음이 아닙니다. 일반적인 GitHub practice 안에서 AI-assisted work를 운영하기 위한 reusable starter kit입니다.
 
 ---
@@ -16,6 +18,8 @@
 ## 트랙 선택하기
 
 원하는 인간 개입 수준에 맞는 workflow를 고르세요.
+
+![Four workflow tracks](./docs/assets/four-tracks-overview.svg)
 
 | 트랙 | 적합한 상황 | 인간 개입 | 상태 |
 | --- | --- | --- | --- |
@@ -36,6 +40,8 @@ Full Vibe Coding은 sandbox repo 또는 protected branch에서만 다룹니다.
 ---
 
 ## 시작하기
+
+![Getting started flow](./docs/assets/getting-started-flow.svg)
 
 1. **[Quickstart Guide](./docs/quickstart.md)**를 읽습니다.
 2. starter file을 자신의 repository에 복사합니다.
@@ -132,6 +138,7 @@ Evaluator-driven experiments need measurable tests or benchmarks.
 │   ├── PULL_REQUEST_TEMPLATE.md
 │   └── workflows/
 ├── docs/
+│   ├── assets/
 │   ├── quickstart.md
 │   ├── case-studies/
 │   ├── experiments/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 It is built for students, teachers, first-time maintainers, and small teams who want AI-assisted coding work to leave a readable engineering history.
 
+![Workflow overview](./docs/assets/workflow-overview.svg)
+
 This is not a prompt dump. It is a reusable starter kit for running AI-assisted work inside normal GitHub practice.
 
 ---
@@ -16,6 +18,8 @@ This is not a prompt dump. It is a reusable starter kit for running AI-assisted 
 ## Choose Your Track
 
 Pick the workflow that matches how much human involvement you want.
+
+![Four workflow tracks](./docs/assets/four-tracks-overview.svg)
 
 | Track | Best for | Human involvement | Status |
 | --- | --- | --- | --- |
@@ -36,6 +40,8 @@ Keep Full Vibe Coding in sandbox repositories or protected branches.
 ---
 
 ## Start Here
+
+![Getting started flow](./docs/assets/getting-started-flow.svg)
 
 1. Read the **[Quickstart Guide](./docs/quickstart.md)**.
 2. Copy the starter files into your repository.
@@ -132,6 +138,7 @@ Evaluator-driven experiments need measurable tests or benchmarks.
 │   ├── PULL_REQUEST_TEMPLATE.md
 │   └── workflows/
 ├── docs/
+│   ├── assets/
 │   ├── quickstart.md
 │   ├── case-studies/
 │   ├── experiments/

--- a/docs/assets/four-tracks-overview.svg
+++ b/docs/assets/four-tracks-overview.svg
@@ -1,0 +1,46 @@
+<svg width="720" height="270" viewBox="0 0 720 270" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Four workflow tracks overview</title>
+  <desc id="desc">A comparison of Review-Driven, GitHub-Native Collaboration, Half Vibe Coding, and Full Vibe Coding tracks.</desc>
+  <style>
+    .text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .title { font-size: 14px; font-weight: 600; }
+    .desc { font-size: 11px; }
+    .tag { font-size: 10px; font-weight: 600; }
+    .node { stroke-width: 1.5; }
+    @media (prefers-color-scheme: dark) {
+      .title, .tag { fill: #adbac7; }
+      .desc { fill: #768390; }
+      .node { fill: #22272e; stroke: #444c56; }
+    }
+    @media (prefers-color-scheme: light) {
+      .title, .tag { fill: #24292f; }
+      .desc { fill: #57606a; }
+      .node { fill: #ffffff; stroke: #d0d7de; }
+    }
+  </style>
+  <rect x="20" y="20" width="320" height="100" rx="7" class="node" />
+  <text x="40" y="48" class="text title">Review-Driven</text>
+  <text x="250" y="48" class="text tag">DEFAULT</text>
+  <text x="40" y="70" class="text desc">Issue → Jules task → PR → CI → human review</text>
+  <text x="40" y="88" class="text desc">Best for real projects, classrooms, and starter repos.</text>
+  <text x="40" y="106" class="text desc">Maintainer owns scope, validation, and merge.</text>
+
+  <rect x="380" y="20" width="320" height="100" rx="7" class="node" />
+  <text x="400" y="48" class="text title">GitHub-Native Collaboration</text>
+  <text x="400" y="70" class="text desc">Learn Issues, PRs, reviews, labels, CI, and rules.</text>
+  <text x="400" y="88" class="text desc">Best for students, teachers, and new maintainers.</text>
+  <text x="400" y="106" class="text desc">Uses the full GitHub workflow as the classroom.</text>
+
+  <rect x="20" y="150" width="320" height="100" rx="7" class="node" />
+  <text x="40" y="178" class="text title">Half Vibe Coding</text>
+  <text x="40" y="200" class="text desc">Human sets direction and checks progress periodically.</text>
+  <text x="40" y="218" class="text desc">Jules executes between checkpoints with strong CI.</text>
+  <text x="40" y="236" class="text desc">Advanced: use after review rules are established.</text>
+
+  <rect x="380" y="150" width="320" height="100" rx="7" class="node" />
+  <text x="400" y="178" class="text title">Full Vibe Coding</text>
+  <text x="610" y="178" class="text tag">EXPERIMENT</text>
+  <text x="400" y="200" class="text desc">Minimal human involvement for sandbox experiments.</text>
+  <text x="400" y="218" class="text desc">Useful for studying autonomous coding workflows.</text>
+  <text x="400" y="236" class="text desc">Not a default path for production repositories.</text>
+</svg>

--- a/docs/assets/getting-started-flow.svg
+++ b/docs/assets/getting-started-flow.svg
@@ -1,0 +1,55 @@
+<svg width="720" height="160" viewBox="0 0 720 160" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Getting started flow</title>
+  <desc id="desc">A five step getting started flow: copy starter files, open an issue, run Jules, review the pull request, and merge.</desc>
+  <style>
+    .text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; font-size: 12px; }
+    .num { font-size: 15px; font-weight: 700; }
+    .circle { stroke-width: 2; }
+    .arrow { stroke-width: 1.5; fill: none; }
+    @media (prefers-color-scheme: dark) {
+      .text, .num { fill: #adbac7; }
+      .circle { fill: #22272e; stroke: #444c56; }
+      .arrow { stroke: #444c56; }
+      .arrow-head { fill: #444c56; }
+    }
+    @media (prefers-color-scheme: light) {
+      .text, .num { fill: #24292f; }
+      .circle { fill: #ffffff; stroke: #d0d7de; }
+      .arrow { stroke: #d0d7de; }
+      .arrow-head { fill: #d0d7de; }
+    }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" class="arrow-head" />
+    </marker>
+  </defs>
+  <circle cx="70" cy="55" r="25" class="circle" />
+  <text x="70" y="61" text-anchor="middle" class="num">1</text>
+  <text x="70" y="108" text-anchor="middle" class="text">Copy starter</text>
+  <text x="70" y="124" text-anchor="middle" class="text">files</text>
+  <line x1="100" y1="55" x2="150" y2="55" class="arrow" marker-end="url(#arrowhead)" />
+
+  <circle cx="190" cy="55" r="25" class="circle" />
+  <text x="190" y="61" text-anchor="middle" class="num">2</text>
+  <text x="190" y="108" text-anchor="middle" class="text">Open small</text>
+  <text x="190" y="124" text-anchor="middle" class="text">Issue</text>
+  <line x1="220" y1="55" x2="270" y2="55" class="arrow" marker-end="url(#arrowhead)" />
+
+  <circle cx="310" cy="55" r="25" class="circle" />
+  <text x="310" y="61" text-anchor="middle" class="num">3</text>
+  <text x="310" y="108" text-anchor="middle" class="text">Run Jules</text>
+  <text x="310" y="124" text-anchor="middle" class="text">from Issue</text>
+  <line x1="340" y1="55" x2="390" y2="55" class="arrow" marker-end="url(#arrowhead)" />
+
+  <circle cx="430" cy="55" r="25" class="circle" />
+  <text x="430" y="61" text-anchor="middle" class="num">4</text>
+  <text x="430" y="108" text-anchor="middle" class="text">Review PR</text>
+  <text x="430" y="124" text-anchor="middle" class="text">and CI</text>
+  <line x1="460" y1="55" x2="510" y2="55" class="arrow" marker-end="url(#arrowhead)" />
+
+  <circle cx="550" cy="55" r="25" class="circle" />
+  <text x="550" y="61" text-anchor="middle" class="num">5</text>
+  <text x="550" y="108" text-anchor="middle" class="text">Merge when</text>
+  <text x="550" y="124" text-anchor="middle" class="text">ready</text>
+</svg>

--- a/docs/assets/workflow-overview.svg
+++ b/docs/assets/workflow-overview.svg
@@ -1,0 +1,46 @@
+<svg width="850" height="150" viewBox="0 0 850 150" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Issue to merge workflow overview</title>
+  <desc id="desc">A GitHub workflow showing Issue, Jules task, pull request, CI, human review, and merge.</desc>
+  <style>
+    .text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; font-size: 13px; }
+    .small { font-size: 11px; }
+    .node { stroke-width: 1.5; }
+    .arrow { stroke-width: 1.5; fill: none; }
+    @media (prefers-color-scheme: dark) {
+      .text { fill: #adbac7; }
+      .node { fill: #22272e; stroke: #444c56; }
+      .arrow { stroke: #444c56; }
+      .arrow-head { fill: #444c56; }
+    }
+    @media (prefers-color-scheme: light) {
+      .text { fill: #24292f; }
+      .node { fill: #ffffff; stroke: #d0d7de; }
+      .arrow { stroke: #d0d7de; }
+      .arrow-head { fill: #d0d7de; }
+    }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" class="arrow-head" />
+    </marker>
+  </defs>
+  <rect x="10" y="55" width="90" height="40" rx="5" class="node" />
+  <text x="55" y="80" text-anchor="middle" class="text">Issue</text>
+  <rect x="150" y="55" width="95" height="40" rx="5" class="node" />
+  <text x="197" y="80" text-anchor="middle" class="text">Jules task</text>
+  <rect x="295" y="55" width="105" height="40" rx="5" class="node" />
+  <text x="347" y="80" text-anchor="middle" class="text">Pull request</text>
+  <rect x="450" y="55" width="90" height="40" rx="5" class="node" />
+  <text x="495" y="80" text-anchor="middle" class="text">CI</text>
+  <rect x="590" y="55" width="120" height="40" rx="5" class="node" />
+  <text x="650" y="80" text-anchor="middle" class="text">Human review</text>
+  <rect x="760" y="55" width="80" height="40" rx="5" class="node" />
+  <text x="800" y="80" text-anchor="middle" class="text">Merge</text>
+  <line x1="100" y1="75" x2="150" y2="75" class="arrow" marker-end="url(#arrowhead)" />
+  <line x1="245" y1="75" x2="295" y2="75" class="arrow" marker-end="url(#arrowhead)" />
+  <line x1="400" y1="75" x2="450" y2="75" class="arrow" marker-end="url(#arrowhead)" />
+  <line x1="540" y1="75" x2="590" y2="75" class="arrow" marker-end="url(#arrowhead)" />
+  <line x1="710" y1="75" x2="760" y2="75" class="arrow" marker-end="url(#arrowhead)" />
+  <path d="M650 55 V30 H197 V55" stroke-dasharray="4" class="arrow" marker-end="url(#arrowhead)" />
+  <text x="420" y="24" text-anchor="middle" class="text small">request changes</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds static SVG visuals to make the README easier to scan without using Mermaid.

## Changes

- Adds `docs/assets/workflow-overview.svg`.
- Adds `docs/assets/four-tracks-overview.svg`.
- Adds `docs/assets/getting-started-flow.svg`.
- Inserts the visuals into `README.md` and `README.ko.md`.
- Keeps the README text readable without depending only on images.
- Uses neutral wording: Jules is framed as an AI coding agent, not a human contributor.

## Validation

- [x] No Mermaid was added.
- [x] SVGs are static and dependency-free.
- [x] Links are relative.
- [x] README.md and README.ko.md remain aligned.
- [x] Maintainer ownership remains explicit.
- [ ] Docs CI passes.

Closes #63.