### PR TITLE
Sync README docs tree after Jules UI guide

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -141,6 +141,8 @@ Evaluator-driven experiments need measurable tests or benchmarks.
 │   └── workflows/
 ├── docs/
 │   ├── assets/
+│   ├── contributing/
+│   ├── jules-web-ui.md
 │   ├── quickstart.md
 │   ├── case-studies/
 │   ├── experiments/

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Evaluator-driven experiments need measurable tests or benchmarks.
 │   └── workflows/
 ├── docs/
 │   ├── assets/
+│   ├── contributing/
+│   ├── jules-web-ui.md
 │   ├── quickstart.md
 │   ├── case-studies/
 │   ├── experiments/


### PR DESCRIPTION
## Summary

Small follow-up after the Jules web UI and translation guide merge.

## Changes

- Updates the README repository structure tree to include `docs/jules-web-ui.md`.
- Updates the README repository structure tree to include `docs/contributing/`.
- Keeps README.md and README.ko.md aligned.

## Validation

- [x] Links to the new guides already exist in Key Guides.
- [x] Docs CI required paths already include the new files.
- [x] This PR only syncs the displayed repository tree.
- [ ] Docs CI passes.
