### PR TITLE
[Jules Task] Add translation contribution issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/translation.yml
+++ b/.github/ISSUE_TEMPLATE/translation.yml
@@ -1,0 +1,66 @@
+name: Translation
+about: Propose a new translation or an improvement to an existing translation
+title: "[Translation] "
+labels: ["translation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for contributing to the translations of the AI Coding Workflow Starter Kit!
+        **Important:** Jules is an AI coding agent, not a human contributor. Contributors are not required to use Jules.
+  - type: input
+    id: target_language
+    attributes:
+      label: Target Language
+      description: What language are you translating into? (e.g., Korean, Spanish, French)
+    validations:
+      required: true
+  - type: input
+    id: document_or_section
+    attributes:
+      label: Document or Section to Translate
+      description: Which document or specific section are you targeting?
+    validations:
+      required: true
+  - type: dropdown
+    id: translation_type
+    attributes:
+      label: Translation Type
+      options:
+        - New translation
+        - Improvement to existing translation
+    validations:
+      required: true
+  - type: input
+    id: source_document_link
+    attributes:
+      label: Source Document Link
+      description: Provide a link to the source document in this repository.
+    validations:
+      required: true
+  - type: textarea
+    id: proposed_scope
+    attributes:
+      label: Proposed Scope
+      description: What specific changes or additions will you make?
+    validations:
+      required: true
+  - type: textarea
+    id: technical_terms
+    attributes:
+      label: Technical Terms
+      description: List any technical terms that should remain unchanged (in English).
+    validations:
+      required: false
+  - type: checkboxes
+    id: preservation_checks
+    attributes:
+      label: Preservation and Meaning
+      description: Please confirm the following guidelines.
+      options:
+        - label: I confirm that links, filenames, and code blocks will be preserved unless intentionally changed.
+          required: true
+        - label: I confirm that technical meaning is preserved in the translation.
+          required: true
+        - label: I confirm that Jules remains described as an AI coding agent, not a human contributor.
+          required: true

--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -116,6 +116,7 @@ jobs:
             "AGENTS.md"
             ".github/PULL_REQUEST_TEMPLATE.md"
             ".github/ISSUE_TEMPLATE/jules_task.yml"
+            ".github/ISSUE_TEMPLATE/translation.yml"
             ".github/ISSUE_TEMPLATE/workflow_experiment.yml"
             "docs/quickstart.md"
             "docs/jules-web-ui.md"

--- a/docs/contributing/first-contributions.md
+++ b/docs/contributing/first-contributions.md
@@ -29,7 +29,7 @@ If you are an educator, your feedback can improve the learning path for classroo
 We welcome translators and international contributors who want to make this starter kit useful beyond English and Korean readers.
 
 - **Translation PR flow:** English (`.md`) is the source language, and Korean (`.ko.md`) is currently maintained as a companion language.
-- **First contribution idea:** Review the [Translation Guide](./translations.md), then open an issue proposing a translation for `docs/quickstart.md` or one operation guide.
+- **First contribution idea:** Review the [Translation Guide](./translations.md), then open an issue using the [Translation Issue Template](../../.github/ISSUE_TEMPLATE/translation.yml) proposing a translation for `docs/quickstart.md` or one operation guide.
 
 ### For Documentation Contributors
 

--- a/docs/contributing/translations.md
+++ b/docs/contributing/translations.md
@@ -25,11 +25,11 @@ In all translations, **Jules must remain described as an AI coding agent**, not 
 
 ## Suggested First Tasks
 
-If you are looking to contribute a translation, here are some recommended starting points:
+If you are looking to contribute a translation, here are some recommended starting points. **To propose a new translation or improve an existing one, please use the [Translation Issue Template](../../.github/ISSUE_TEMPLATE/translation.yml).**
 
 1. **Translate the Quickstart Guide:** Help new users get started by translating `docs/quickstart.md`.
 2. **Translate Operations Guides:** Choose a guide from `docs/operations/` and provide a translated version.
 3. **Audit Existing Translations:** Review `README.ko.md` and suggest improvements for clarity or accuracy.
-4. **Propose a New Language:** If you would like to translate the starter kit into a new language, please open an issue first to discuss the structure (e.g., using `.es.md`, `.fr.md`, etc.).
+4. **Propose a New Language:** If you would like to translate the starter kit into a new language, please open a translation issue first to discuss the structure (e.g., using `.es.md`, `.fr.md`, etc.).
 
 Thank you for helping us reach more developers!


### PR DESCRIPTION
Resolves #74.

### Validation Notes:
- **YAML Syntax:** Verified locally using the ruby YAML parsing logic from `docs-and-templates.yml`. `translation.yml` passes cleanly.
- **New Links:** Verified that links added in `translations.md` and `first-contributions.md` correctly resolve relatively to `.github/ISSUE_TEMPLATE/translation.yml`.
- **Markdown Hygiene:** Verified via the Python script from `docs-and-templates.yml`; no newlines missing, no tabs introduced, no extra trailing spaces.
- **Docs CI:** Updated `docs-and-templates.yml` to track the existence of the new `translation.yml` template and passed structural checks locally.
- **Contributors Not Required to Use Jules:** Explicitly confirmed by adding a markdown block in the new template to remind contributors of this fact.
- **Preserve Technical Meaning:** Checkboxes asking contributors to preserve meaning and AI agent framing were added directly to the template.

---
*PR created automatically by Jules for task [17147217432737061702](https://jules.google.com/task/17147217432737061702) started by @hkimw*