### PR TITLE
Add translation contribution issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/translation.yml
+++ b/.github/ISSUE_TEMPLATE/translation.yml
@@ -1,0 +1,70 @@
+name: Translation
+about: Propose a new translation or improve an existing one
+title: "[Translation] "
+labels: ["translation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping make this project accessible! Please refer to the [Translation Guide](../../docs/contributing/translations.md) before submitting.
+  - type: input
+    id: language
+    attributes:
+      label: Target Language
+      placeholder: e.g., Spanish, French, Japanese, etc.
+    validations:
+      required: true
+  - type: input
+    id: document
+    attributes:
+      label: Document or Section
+      placeholder: e.g., docs/quickstart.md, README.md, or a specific section
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: Translation Type
+      options:
+        - New translation
+        - Improvement to an existing translation
+    validations:
+      required: true
+  - type: input
+    id: source_link
+    attributes:
+      label: Source Document Link
+      placeholder: Link to the English version of the document
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Proposed Scope
+      description: What exactly are you planning to translate or improve?
+    validations:
+      required: true
+  - type: textarea
+    id: technical_terms
+    attributes:
+      label: Technical Terms
+      description: List any technical terms that should remain unchanged in the target language.
+      placeholder: e.g., Jules, PR, CI, etc.
+  - type: checkboxes
+    id: preservation
+    attributes:
+      label: Preservation of technical structure
+      options:
+        - label: I have preserved all relative links and filenames.
+          required: true
+        - label: I have kept code blocks, terminal commands, and configuration snippets unchanged (except for comments if necessary).
+          required: true
+  - type: checkboxes
+    id: principles
+    attributes:
+      label: Translation Principles
+      options:
+        - label: I confirm that Jules is described as an AI coding agent, not a human contributor.
+          required: true
+        - label: I have preserved the technical meaning and engineering practices of the original text.
+          required: true

--- a/.github/ISSUE_TEMPLATE/translation.yml
+++ b/.github/ISSUE_TEMPLATE/translation.yml
@@ -6,7 +6,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for helping make this project accessible! Please refer to the [Translation Guide](../../docs/contributing/translations.md) before submitting.
+        Thank you for helping make this project accessible. Please refer to the [Translation Guide](../../docs/contributing/translations.md) before submitting.
+
+        Contributors are not required to use Jules. Jules should remain described as an AI coding agent, not a human contributor.
   - type: input
     id: language
     attributes:
@@ -57,7 +59,7 @@ body:
       options:
         - label: I have preserved all relative links and filenames.
           required: true
-        - label: I have kept code blocks, terminal commands, and configuration snippets unchanged (except for comments if necessary).
+        - label: I have kept code blocks, terminal commands, and configuration snippets unchanged, except for comments if necessary.
           required: true
   - type: checkboxes
     id: principles

--- a/.github/workflows/docs-and-templates.yml
+++ b/.github/workflows/docs-and-templates.yml
@@ -117,6 +117,7 @@ jobs:
             ".github/PULL_REQUEST_TEMPLATE.md"
             ".github/ISSUE_TEMPLATE/jules_task.yml"
             ".github/ISSUE_TEMPLATE/workflow_experiment.yml"
+            ".github/ISSUE_TEMPLATE/translation.yml"
             "docs/quickstart.md"
             "docs/jules-web-ui.md"
             "docs/contributing/first-contributions.md"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ Issue → Jules task → Pull Request → CI → Human Review → Merge
 All changes must start with a GitHub Issue.
 
 - **For standard tasks:** Use the **Jules Task** template. This template is designed to provide clear, scoped instructions for Jules.
+- **For translations:** Use the **Translation** template to propose new translations or improve existing ones.
 - **For experiments:** Use the **Workflow Experiment** template if you are proposing a new automation level or a sandbox experiment.
 
 ### 2. Preparing a Jules Task

--- a/docs/contributing/first-contributions.md
+++ b/docs/contributing/first-contributions.md
@@ -29,7 +29,7 @@ If you are an educator, your feedback can improve the learning path for classroo
 We welcome translators and international contributors who want to make this starter kit useful beyond English and Korean readers.
 
 - **Translation PR flow:** English (`.md`) is the source language, and Korean (`.ko.md`) is currently maintained as a companion language.
-- **First contribution idea:** Review the [Translation Guide](./translations.md), then open an issue proposing a translation for `docs/quickstart.md` or one operation guide.
+- **First contribution idea:** Review the [Translation Guide](./translations.md), then [open a translation issue](../../.github/ISSUE_TEMPLATE/translation.yml) proposing a translation for `docs/quickstart.md` or one operation guide.
 
 ### For Documentation Contributors
 

--- a/docs/contributing/translations.md
+++ b/docs/contributing/translations.md
@@ -30,6 +30,6 @@ If you are looking to contribute a translation, here are some recommended starti
 1. **Translate the Quickstart Guide:** Help new users get started by translating `docs/quickstart.md`.
 2. **Translate Operations Guides:** Choose a guide from `docs/operations/` and provide a translated version.
 3. **Audit Existing Translations:** Review `README.ko.md` and suggest improvements for clarity or accuracy.
-4. **Propose a New Language:** If you would like to translate the starter kit into a new language, please open an issue first to discuss the structure (e.g., using `.es.md`, `.fr.md`, etc.).
+4. **Propose a New Language:** If you would like to translate the starter kit into a new language, please [open a translation issue](../../.github/ISSUE_TEMPLATE/translation.yml) first to discuss the structure (e.g., using `.es.md`, `.fr.md`, etc.).
 
 Thank you for helping us reach more developers!

--- a/docs/contributing/translations.md
+++ b/docs/contributing/translations.md
@@ -1,6 +1,6 @@
 # Translation Guide
 
-We explicitly welcome translation contributors to help make the AI Coding Workflow Starter Kit accessible to a global audience.
+We welcome translation contributors who want to make the AI Coding Workflow Starter Kit easier to use across languages.
 
 ## Translation Principles
 
@@ -32,4 +32,4 @@ If you are looking to contribute a translation, here are some recommended starti
 3. **Audit Existing Translations:** Review `README.ko.md` and suggest improvements for clarity or accuracy.
 4. **Propose a New Language:** If you would like to translate the starter kit into a new language, please [open a translation issue](../../.github/ISSUE_TEMPLATE/translation.yml) first to discuss the structure (e.g., using `.es.md`, `.fr.md`, etc.).
 
-Thank you for helping us reach more developers!
+Translation work should keep the workflow accurate, reviewable, and useful for maintainers in different language communities.


### PR DESCRIPTION
This PR introduces a dedicated GitHub Issue template for translation contributions, making it easier for international contributors to propose and manage translations.

Key changes:
- **New Issue Template:** `.github/ISSUE_TEMPLATE/translation.yml` collects target language, document/section, translation type, source link, scope, and technical terms. It also includes mandatory checklists to ensure preservation of technical meaning and adherence to the project's principle that Jules is an AI agent.
- **Documentation Updates:** `docs/contributing/translations.md`, `docs/contributing/first-contributions.md`, and `CONTRIBUTING.md` now link to the new template for better discoverability.
- **CI Integration:** The new template is added to the `.github/workflows/docs-and-templates.yml` structural checks.

Validation:
- YAML syntax of the new template is valid.
- Markdown hygiene passes for all modified files.
- Starter kit structure validation includes the new template.
- Links are relative and correct.

Fixes #74

---
*PR created automatically by Jules for task [10086717024359695145](https://jules.google.com/task/10086717024359695145) started by @hkimw*