### PR TITLE
Add issue draft for Case Study A index page cleanup

### DIFF
--- a/examples/issues/case-study-a-cleanup.md
+++ b/examples/issues/case-study-a-cleanup.md
@@ -1,0 +1,34 @@
+# [Jules Task] Case Study A index page cleanup
+
+## Problem
+The Case Study A index page (`docs/case-studies/digital-logic-circuit.md`) was created as a placeholder during the initial setup. Now that the starter kit is being applied, the page needs to be updated to accurately describe the repository's role, the status of the workflow installation, and the clear separation of responsibilities between Jules and the human maintainer.
+
+## Scope
+Modify `docs/case-studies/digital-logic-circuit.md` to include:
+- **Repository Role:** Clarify that `digital-logic-circuit` is the primary real-world applied case study for this workflow.
+- **Workflow Installation Status:** Provide an update on how the starter kit is being integrated into the target project.
+- **Linked Issue/PR Placeholders:** Insert placeholders for traceability (e.g., "[Link to Example Issue]", "[Link to Example PR]").
+- **Division of Labor:**
+  - Define what Jules assists with (implementation, PR creation, small-scoped tasks).
+  - Define what the human maintainer owns (architecture, hardware validation, final review).
+- **Traceable Steps:** Add a "Next Steps" section explaining how readers can follow the work.
+
+## Non-goals
+- Do not claim the case study is complete.
+- Do not claim hardware validation without attached logs.
+- Do not present Jules as a human contributor.
+- Do not modify the target `digital-logic-circuit` repository itself.
+
+## Acceptance Criteria
+- [ ] Use evidence-based wording for project status.
+- [ ] Maintain a clear distinction between the workflow template and the applied case study.
+- [ ] Use relative links for internal documentation where possible.
+- [ ] Adhere strictly to the AGENTS.md guidelines regarding Jules's identity.
+
+## Validation
+- Perform a manual read-through of the proposed changes.
+- Check that all Markdown links are valid and relative.
+- Ensure the separation of responsibilities matches the core philosophy of the starter kit.
+
+## Workflow Level
+Level 1 - Human-led Jules workflow


### PR DESCRIPTION
This PR adds a new issue draft in the examples directory to track the cleanup of the Case Study A index page. The draft follows the jules_task.yml template and includes the required scope for updating repository roles, workflow status, and division of labor between Jules and the human maintainer. Remote issue creation was not performed due to sandbox environment limitations.

Fixes #109

---
*PR created automatically by Jules for task [8986680583658488862](https://jules.google.com/task/8986680583658488862) started by @hkimw*