### PR TITLE
Create issue for English-only Case Study B candidate criteria

### DIFF
--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -14,6 +14,7 @@ Jules performs best when the problem and scope are clearly defined. A well-scope
 - [Documentation Task](./docs-task.md): Adding or updating documentation.
 - [CI/Tooling Task](./ci-task.md): Modifying GitHub Actions or local scripts.
 - [Scoped Refactor Task](./refactor-task.md): Cleaning up code without changing behavior.
+- [Case Study B Planning](./case-study-b-planning/selection-criteria.md): Defining criteria for an English-only project.
 
 ## How to Use These Examples
 

--- a/examples/issues/case-study-b-planning/selection-criteria.md
+++ b/examples/issues/case-study-b-planning/selection-criteria.md
@@ -1,0 +1,29 @@
+# Issue: English-only Case Study B candidate criteria
+
+## Goal
+Create an issue defining criteria for the future English-only Case Study B repo.
+
+## Selection Criteria
+The candidate project for Case Study B should meet the following criteria:
+- **Small scope**: Can be completed in a few focused issues/PRs.
+- **Easy to test**: High confidence in automated verification.
+- **English-only**: All code, documentation, and issues must be in English.
+- **Beginner-readable**: Accessible to students and new contributors.
+- **CI-friendly**: Runs quickly in GitHub Actions without complex setup.
+- **Good for small Jules-assisted PRs**: Tasks can be easily broken down.
+- **Not hardware-dependent**: Unlike Case Study A, it should run entirely in a standard software environment.
+
+## Candidate Project Ideas
+1. **`md-link-linter`**: A CLI tool that scans Markdown files for broken or suboptimal links.
+2. **`json-schema-validator-cli`**: A small utility to validate JSON files against a schema.
+3. **`todo-cli-app`**: A classic minimal todo list manager to demonstrate standard CRUD-like logic and persistence.
+
+## Comparison with Case Study A
+| Feature | Case Study A (Digital Logic) | Case Study B (English-only) |
+| --- | --- | --- |
+| **Domain** | Hardware/Software Capstone | General Software Tooling |
+| **Language** | Multi-lingual (English/Korean) | English-only |
+| **Dependencies** | Hardware-specific / Simulation | Standard software environments |
+| **Purpose** | Real-world complex integration | Process clarity and global readability |
+
+Case Study B is designed to prove that the Jules workflow is reusable and effective for a wide audience without the domain-specific overhead of a capstone project.


### PR DESCRIPTION
I have drafted the selection criteria and candidate project ideas for Case Study B.

Key changes:
- Created `examples/issues/case-study-b-planning/selection-criteria.md` containing the defined criteria, candidate ideas, and comparison with Case Study A.
- Updated `examples/issues/README.md` to include a link to the new planning draft.
- Verified Markdown hygiene for both files.

Selection Criteria included:
- Small scope
- Easy to test
- English-only
- Beginner-readable
- CI-friendly
- Good for small Jules-assisted PRs
- Not hardware-dependent

Candidate Projects:
1. `md-link-linter`
2. `json-schema-validator-cli`
3. `todo-cli-app`

Note: As the environment does not provide GitHub authentication for the `gh` tool, I have prepared the issue as a reusable Markdown file within the repository's example structure.


Fixes #118

---
*PR created automatically by Jules for task [6063948528500494530](https://jules.google.com/task/6063948528500494530) started by @hkimw*