### PR TITLE
Create issue draft for jules-workflow-template README

### DIFF
--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -14,6 +14,7 @@ Jules performs best when the problem and scope are clearly defined. A well-scope
 - [Documentation Task](./docs-task.md): Adding or updating documentation.
 - [CI/Tooling Task](./ci-task.md): Modifying GitHub Actions or local scripts.
 - [Scoped Refactor Task](./refactor-task.md): Cleaning up code without changing behavior.
+- [Template README Task](./template-readme-task.md): Drafting a README for a template repository.
 
 ## How to Use These Examples
 

--- a/examples/issues/template-readme-task.md
+++ b/examples/issues/template-readme-task.md
@@ -1,0 +1,31 @@
+# [Jules Task] Draft README for jules-workflow-template
+
+## Problem
+The `jules-workflow-template` repository needs a concise, practical README to guide users on how to use the starter kit files in their own projects.
+
+## Scope
+Draft a `README.md` for the template repository that includes:
+- **What this template is:** A "copy-first" repository containing the essential files for the Jules workflow.
+- **Quick usage steps:** How to use this template to start a new project or apply it to an existing one.
+- **Files included:** Briefly list the core files (AGENTS.md, templates, prompts, etc.).
+- **Default workflow:** Explicitly state the Review-Driven workflow (Issue -> PR -> Review -> Merge).
+- **Safety notes:** Clarify Jules's role as an AI coding agent and the requirement for human maintainer review.
+- **Link back to hub:** Provide a link to the main `vibe-coding-with-jules` playbook for more detailed guides.
+
+## Non-goals
+- Do not create a long playbook (link back to the hub instead).
+- Do not add marketing hype or star-begging.
+- Do not present autonomous workflows as the default.
+
+## Acceptance Criteria
+- [ ] The README draft is short and practical.
+- [ ] Human maintainer review is explicitly required before merging.
+- [ ] Jules is clearly framed as an AI coding agent.
+- [ ] All requested sections (usage, files, workflow, safety, hub link) are present.
+
+## Validation
+- Review the draft for clarity and conciseness.
+- Verify that it aligns with the principles in `AGENTS.md`.
+
+## Workflow Level
+- Level 1 - Human-led Jules workflow


### PR DESCRIPTION
I have created a draft issue for creating the `jules-workflow-template` README. Since the GitHub CLI (`gh`) is not authenticated in this environment, I have stored the issue content in `examples/issues/template-readme-task.md` and updated the `examples/issues/README.md` index to include it.

The draft issue requests a concise README that covers:
- Purpose of the template
- Quick usage steps
- Files included
- Default Review-Driven workflow
- Safety notes framing Jules as an AI agent
- Link back to the main hub

This allows the maintainer to easily create the issue on GitHub by copying the content from the repository.

Fixes #112

---
*PR created automatically by Jules for task [10188338643138302478](https://jules.google.com/task/10188338643138302478) started by @hkimw*