### PR TITLE
Create example for good-first-issues refresh

### DIFF
--- a/examples/issues/refresh-good-first-issues.md
+++ b/examples/issues/refresh-good-first-issues.md
@@ -1,0 +1,32 @@
+## Goal
+Refresh the "good first issues" list with new, high-quality documentation and template-oriented tasks for students, teachers, and first-time maintainers.
+
+## Problem
+The current set of good first issues needs expansion to better serve the target audience (students, teachers, first-time maintainers) with practical, low-risk documentation and template tasks.
+
+## Scope
+- Identify 5-8 beginner-friendly contribution ideas.
+- Keep tasks docs/template-oriented.
+- Avoid requiring repo admin settings or code changes.
+- Include Korean companion-doc opportunities where useful.
+
+## Proposed Candidate Tasks
+1.  **Audit Quickstart for Clarity**: Review `docs/quickstart.md` for technical accuracy and flow. Suggest small wording improvements.
+2.  **Korean Translation for Quickstart**: Provide a companion translation for `docs/quickstart.md` to `docs/quickstart.ko.md`.
+3.  **Improve Label Descriptions**: Suggest clearer descriptions for the recommended labels in `docs/operations/labels-and-triage.md`.
+4.  **Case Study B Draft Feedback**: Review the actionable plan for Case Study B (`docs/case-studies/english-only-project.md`) and suggest one improvement for student readability.
+5.  **New Example Issue Template**: Propose a new example issue in `examples/issues/` for a common documentation task (e.g., adding a troubleshooting section).
+6.  **Audit AGENTS.md**: Review `AGENTS.md` for any ambiguous rules and propose clarifying edits.
+7.  **PR Review Example**: Contribute a clear example of a human maintainer review comment to `examples/pr-reviews/`.
+8.  **Link Validation**: Manually check all internal documentation links for accuracy and report any broken or misdirected links.
+
+## Non-goals
+- Do not create labels or modify repository settings.
+- Do not assign contributors.
+- Do not add promotional language or fake popularity claims.
+
+## Acceptance Criteria
+- [ ] The issue lists clear, practical candidate tasks.
+- [ ] Public docs remain English-first.
+- [ ] Korean companion-doc opportunities are included.
+- [ ] All tasks avoid code changes and repo admin requirements.


### PR DESCRIPTION
I have identified 8 beginner-friendly contribution ideas focusing on documentation and templates, avoiding code changes or repo admin settings. Since direct issue creation via CLI was not possible due to missing GitHub authentication, I have added these ideas as a new example issue file in `examples/issues/refresh-good-first-issues.md`. This allows maintainers to easily copy the content into a new issue while also improving the repository's set of reference examples. All changes have been validated against the project's Markdown hygiene and structure requirements.

Fixes #110

---
*PR created automatically by Jules for task [660276898987623958](https://jules.google.com/task/660276898987623958) started by @hkimw*