### PR TITLE
Consolidate remaining template example issue drafts

### DIFF
--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -15,6 +15,10 @@ Jules performs best when the problem and scope are clearly defined. A well-scope
 - [CI/Tooling Task](./ci-task.md): Modifying GitHub Actions or local scripts.
 - [Scoped Refactor Task](./refactor-task.md): Cleaning up code without changing behavior.
 - [Template AGENTS Task](./template-agents-task.md): Drafting minimal rules for a template repository.
+- [Template README Task](./template-readme-task.md): Drafting a copy-first README for a new repository.
+- [Minimal PR Template Task](./pr-template-task.md): Drafting a reusable PR template.
+- [Lightweight CI Task](./lightweight-ci-task.md): Adding minimal docs and template validation.
+- [Case Study B Task](./case-study-b-task.md): Initializing an English-only sample project.
 
 ## How to Use These Examples
 

--- a/examples/issues/case-study-b-task.md
+++ b/examples/issues/case-study-b-task.md
@@ -1,0 +1,33 @@
+# [Jules Task] Create Case Study B repository: `md-link-linter`
+
+## Problem
+We need to implement the actionable plan for Case Study B by creating a small, English-only open-source project that demonstrates the Jules workflow. This will serve as a practical example for a global audience.
+
+## Scope
+- Initialize a new public repository `md-link-linter`.
+- Set up the initial project structure (Python-based).
+- Copy and adapt the following files from the starter kit:
+  - `AGENTS.md`
+  - `.github/ISSUE_TEMPLATE/`
+  - `.github/PULL_REQUEST_TEMPLATE.md`
+  - A lightweight GitHub Actions workflow for CI.
+- Open the first 5 scoped issues as defined in `docs/case-studies/english-only-project.md`.
+
+## Non-goals
+- Do not build a large, complex application.
+- Do not include multi-language support (English-only for this case study).
+- Do not automate merging without human review.
+
+## Acceptance Criteria
+- [ ] Repository `md-link-linter` is public and initialized.
+- [ ] Core workflow files (`AGENTS.md`, templates, CI) are present and adapted.
+- [ ] Initial 5 issues are created and follow the standard template.
+- [ ] README links back to the vibe-coding-with-jules hub.
+
+## Validation
+- Confirm the repository URL is accessible.
+- Verify that the first 5 issues are visible and correctly formatted.
+- Ensure the initial CI run passes.
+
+## Workflow Level
+- Level 1 - Human-led Jules workflow

--- a/examples/issues/lightweight-ci-task.md
+++ b/examples/issues/lightweight-ci-task.md
@@ -1,0 +1,28 @@
+# [Jules Task] Add lightweight CI for docs and templates
+
+## Problem
+The template repository needs a way to automatically validate documentation hygiene (no trailing spaces, final newline) and issue template YAML syntax to prevent regressions. It should be lightweight and avoid complex dependencies.
+
+## Scope
+- Create `.github/workflows/docs-and-templates.yml`.
+- Add a job to validate YAML syntax in `.github/ISSUE_TEMPLATE/`.
+- Add a job to validate Markdown hygiene (trailing spaces, final newline).
+- Ensure the workflow runs on pull requests and pushes to `main`.
+
+## Non-goals
+- Do not add complex code coverage or deployment scripts.
+- Do not add third-party actions unless necessary and minimal.
+- Do not modify existing documentation.
+
+## Acceptance Criteria
+- [ ] `.github/workflows/docs-and-templates.yml` exists and is valid.
+- [ ] YAML validation correctly identifies syntax errors in templates.
+- [ ] Markdown validation correctly identifies hygiene issues.
+
+## Validation
+- Introduce a temporary YAML error to verify CI fails.
+- Introduce a temporary trailing space to verify CI fails.
+- Ensure CI passes once errors are corrected.
+
+## Workflow Level
+- Level 1 - Human-led Jules workflow

--- a/examples/issues/pr-template-task.md
+++ b/examples/issues/pr-template-task.md
@@ -1,0 +1,29 @@
+# [Jules Task] Draft minimal PR template for template repository
+
+## Problem
+The future template repository needs a minimal, reusable Pull Request template. The current PR template in the hub repository contains hub-specific workflow levels and experiment options that might be too complex for a new project.
+
+## Scope
+- Draft a minimal `.github/PULL_REQUEST_TEMPLATE.md` for the template repository.
+- Include the following essential sections:
+  - **Summary**: A brief description of changes.
+  - **Linked Issue**: A mandatory link to the originating issue.
+  - **Validation**: Checkboxes for tests and manual validation notes.
+  - **Scope Control**: Affirmations that no unrelated changes or refactors are included.
+  - **Maintainer Review Checklist**: A short list of checks for the human reviewer.
+
+## Non-goals
+- Do not include hub-specific workflow levels (Level 4, Experiments, etc.).
+- Do not add complex automation or bot instructions to the template.
+
+## Acceptance Criteria
+- [ ] The drafted PR template is concise and reusable.
+- [ ] Essential safety and validation checks are preserved.
+- [ ] The template reinforces the human-led Review-Driven workflow.
+
+## Validation
+- Review the drafted template for clarity and completeness.
+- Ensure the Markdown syntax is correct.
+
+## Workflow Level
+- Level 1 - Human-led Jules workflow

--- a/examples/issues/template-readme-task.md
+++ b/examples/issues/template-readme-task.md
@@ -1,0 +1,31 @@
+# [Jules Task] Create minimal README for `jules-workflow-template`
+
+## Problem
+The future `jules-workflow-template` repository needs a concise, "copy-first" README that explains its purpose and how to use it. It should be stripped of the hub's metadata and complex workflow tracks to remain a clean starting point for users.
+
+## Scope
+- Create a minimal `README.md` for the template repository.
+- Include the following sections:
+  - **Purpose**: Explain that this is a minimal starting point for the Jules workflow.
+  - **Getting Started**: Steps to use the template (Use this template, open an issue, etc.).
+  - **Included Files**: List the core starter files (`AGENTS.md`, `.github/`, `prompts/`).
+  - **Default Workflow**: Explain the Review-Driven workflow.
+  - **Safety Note**: Frame Jules as an AI coding agent.
+  - **Link back to Hub**: Provide a link to the `vibe-coding-with-jules` hub for full documentation.
+
+## Non-goals
+- Do not include multi-track workflow diagrams from the hub.
+- Do not include hub-specific case studies or meta docs.
+- Do not use promotional language.
+
+## Acceptance Criteria
+- [ ] The README is concise and easy to follow.
+- [ ] It clearly directs users to the full hub for advanced topics.
+- [ ] It establishes the Review-Driven workflow as the default.
+
+## Validation
+- Review the drafted README for clarity and tone.
+- Ensure Markdown hygiene (no trailing spaces, final newline).
+
+## Workflow Level
+- Level 1 - Human-led Jules workflow


### PR DESCRIPTION
Consolidate the remaining future-template example issue drafts into one focused docs-only PR.

Created four new example issue files in `examples/issues/`:
1. `lightweight-ci-task.md`
2. `case-study-b-task.md`
3. `pr-template-task.md`
4. `template-readme-task.md`

Updated `examples/issues/README.md` to include these new examples.

Validation:
- Markdown hygiene checked (final newline, no trailing spaces).
- YAML syntax checked for existing templates.
- Content follows the "Jules Task" structure and hub-specific constraints.

Fixes #227

---
*PR created automatically by Jules for task [13706381401572127570](https://jules.google.com/task/13706381401572127570) started by @hkimw*