### PR TITLE
Improve README role separation and add example task

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -17,11 +17,11 @@
 
 ## 한 개의 저장소, 세 가지 역할
 
-이 저장소는 여러분이 AI-assisted coding을 도입하는 데 도움이 되도록 세 가지 뚜렷한 목적으로 운영됩니다:
+이 저장소는 AI-assisted coding을 위한 중앙 **Hub이자 Playbook**이며, 각 기능 사이의 명확한 경계를 유지하며 운영됩니다:
 
-1.  **[Hub / Playbook](./docs/quickstart.md)**: GitHub-native Jules workflow를 배우기 위한 중앙 거점입니다. 트랙, 운영, 안전에 관한 가이드를 제공합니다.
-2.  **[Starter Kit](./docs/showcase.md)**: 새로운 저장소에 바로 적용할 수 있는 "copy-first" 파일들(`AGENTS.md`, template, prompt)의 모음입니다.
-3.  **[Case Studies](./docs/case-studies/)**: 다양한 도메인에서 이 workflow가 실제로 작동하는 것을 보여주는 증거와 계획된 프로젝트들입니다.
+1.  **[Hub / Playbook](./docs/quickstart.md)**: GitHub-native Jules workflow를 배우기 위한 결정적인 거점입니다. 트랙, 운영, 안전에 관한 가이드를 제공합니다.
+2.  **[재사용 가능한 Starter File](./docs/showcase.md)**: 새로운 프로젝트에 바로 적용할 수 있는 이 저장소의 "copy-first" 파일들(`AGENTS.md`, template, prompt)의 모음입니다. 이 파일들은 향후 전용 템플릿 저장소인 **[jules-workflow-template](https://github.com/google-labs/jules-workflow-template)**의 기반이 됩니다.
+3.  **[Case Studies](./docs/case-studies/)**: **[Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)**와 같이 이 workflow가 실제로 작동하는 것을 보여주는 실제 사례들입니다.
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -19,8 +19,8 @@
 
 이 저장소는 AI-assisted coding을 위한 중앙 **Hub이자 Playbook**이며, 각 기능 사이의 명확한 경계를 유지하며 운영됩니다:
 
-1.  **[Hub / Playbook](./docs/quickstart.md)**: GitHub-native Jules workflow를 배우기 위한 결정적인 거점입니다. 트랙, 운영, 안전에 관한 가이드를 제공합니다.
-2.  **[재사용 가능한 Starter File](./docs/showcase.md)**: 새로운 프로젝트에 바로 적용할 수 있는 이 저장소의 "copy-first" 파일들(`AGENTS.md`, template, prompt)의 모음입니다. 이 파일들은 향후 전용 템플릿 저장소인 **[jules-workflow-template](https://github.com/google-labs/jules-workflow-template)**의 기반이 됩니다.
+1.  **[Hub / Playbook](./docs/quickstart.md)**: GitHub-native Jules workflow를 배우기 위한 중앙 거점입니다. 트랙, 운영, 안전에 관한 가이드를 제공합니다.
+2.  **[재사용 가능한 Starter File](./docs/showcase.md)**: 새로운 프로젝트에 바로 적용할 수 있는 이 저장소의 "copy-first" 파일들(`AGENTS.md`, template, prompt)의 모음입니다. 이 파일들은 향후 전용 템플릿 저장소인 **[jules-workflow-template](https://github.com/hkimw-underground/jules-workflow-template)**의 기반이 됩니다.
 3.  **[Case Studies](./docs/case-studies/)**: **[Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)**와 같이 이 workflow가 실제로 작동하는 것을 보여주는 실제 사례들입니다.
 
 ---

--- a/README.ko.md
+++ b/README.ko.md
@@ -15,6 +15,16 @@
 
 ---
 
+## 한 개의 저장소, 세 가지 역할
+
+이 저장소는 여러분이 AI-assisted coding을 도입하는 데 도움이 되도록 세 가지 뚜렷한 목적으로 운영됩니다:
+
+1.  **[Hub / Playbook](./docs/quickstart.md)**: GitHub-native Jules workflow를 배우기 위한 중앙 거점입니다. 트랙, 운영, 안전에 관한 가이드를 제공합니다.
+2.  **[Starter Kit](./docs/showcase.md)**: 새로운 저장소에 바로 적용할 수 있는 "copy-first" 파일들(`AGENTS.md`, template, prompt)의 모음입니다.
+3.  **[Case Studies](./docs/case-studies/)**: 다양한 도메인에서 이 workflow가 실제로 작동하는 것을 보여주는 증거와 계획된 프로젝트들입니다.
+
+---
+
 ## 트랙 선택하기
 
 원하는 인간 개입 수준에 맞는 workflow를 고르세요.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ This is not a prompt dump. It is a reusable starter kit for running AI-assisted 
 
 ---
 
+## One Repository, Three Roles
+
+This repository serves three distinct purposes to help you adopt AI-assisted coding:
+
+1.  **[The Hub / Playbook](./docs/quickstart.md)**: The central place for learning the GitHub-native Jules workflow, featuring guides on tracks, operations, and safety.
+2.  **[The Starter Kit](./docs/showcase.md)**: A collection of "copy-first" files (`AGENTS.md`, templates, prompts) designed to be dropped into any new repository.
+3.  **[The Case Studies](./docs/case-studies/)**: Real-world evidence and planned projects showing the workflow in action across different domains.
+
+---
+
 ## Choose Your Track
 
 Pick the workflow that matches how much human involvement you want.

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ This is not a prompt dump. It is a reusable starter kit for running AI-assisted 
 
 ## One Repository, Three Roles
 
-This repository serves three distinct purposes to help you adopt AI-assisted coding:
+This repository serves as the central **Hub and Playbook** for AI-assisted coding, while maintaining clear boundaries between its different functions:
 
-1.  **[The Hub / Playbook](./docs/quickstart.md)**: The central place for learning the GitHub-native Jules workflow, featuring guides on tracks, operations, and safety.
-2.  **[The Starter Kit](./docs/showcase.md)**: A collection of "copy-first" files (`AGENTS.md`, templates, prompts) designed to be dropped into any new repository.
-3.  **[The Case Studies](./docs/case-studies/)**: Real-world evidence and planned projects showing the workflow in action across different domains.
+1.  **[The Hub / Playbook](./docs/quickstart.md)**: The definitive place for learning the GitHub-native Jules workflow, featuring guides on tracks, operations, and safety.
+2.  **[Reusable Starter Files](./docs/showcase.md)**: A collection of "copy-first" files (`AGENTS.md`, templates, prompts) found in this repo that you can drop into any new project. These files also power the future dedicated **[jules-workflow-template](https://github.com/google-labs/jules-workflow-template)** repository.
+3.  **[The Case Studies](./docs/case-studies/)**: Real-world evidence, such as **[Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)**, showing the workflow in action.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is not a prompt dump. It is a reusable starter kit for running AI-assisted 
 This repository serves as the central **Hub and Playbook** for AI-assisted coding, while maintaining clear boundaries between its different functions:
 
 1.  **[The Hub / Playbook](./docs/quickstart.md)**: The definitive place for learning the GitHub-native Jules workflow, featuring guides on tracks, operations, and safety.
-2.  **[Reusable Starter Files](./docs/showcase.md)**: A collection of "copy-first" files (`AGENTS.md`, templates, prompts) found in this repo that you can drop into any new project. These files also power the future dedicated **[jules-workflow-template](https://github.com/google-labs/jules-workflow-template)** repository.
+2.  **[Reusable Starter Files](./docs/showcase.md)**: A collection of "copy-first" files (`AGENTS.md`, templates, prompts) found in this repo that you can drop into any new project. These files also power the future dedicated **[jules-workflow-template](https://github.com/hkimw-underground/jules-workflow-template)** repository.
 3.  **[The Case Studies](./docs/case-studies/)**: Real-world evidence, such as **[Case Study A: Digital Logic Circuit](./docs/case-studies/digital-logic-circuit.md)**, showing the workflow in action.
 
 ---

--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -19,6 +19,7 @@ Jules performs best when the problem and scope are clearly defined. A well-scope
 - [Minimal PR Template Task](./pr-template-task.md): Drafting a reusable PR template.
 - [Lightweight CI Task](./lightweight-ci-task.md): Adding minimal docs and template validation.
 - [Case Study B Task](./case-study-b-task.md): Initializing an English-only sample project.
+- [README Role Separation Task](./readme-role-separation.md): Improving top-level role separation for the Hub, Template, and Case Studies.
 
 ## How to Use These Examples
 

--- a/examples/issues/readme-role-separation.md
+++ b/examples/issues/readme-role-separation.md
@@ -1,14 +1,14 @@
 # [Jules Task] Improve README role separation
 
 ## Problem
-The current top-level `README.md` is packed with information, making it difficult for first-time visitors to distinguish between the various roles this repository plays: as a Playbook (Hub), a Starter Kit (Template), and a collection of Case Studies.
+The current top-level `README.md` is packed with information, making it difficult for first-time visitors to distinguish between the various roles this repository plays: as a Playbook (Hub), a source for reusable starter files, and a collection of Case Studies. We must ensure this repository is not confused with the future dedicated template repository.
 
 ## Scope
 - Update `README.md` and `README.ko.md` to include a clear "One Repository, Three Roles" section.
 - This section should briefly define:
-  - **The Hub / Playbook**: The central place for learning GitHub-native AI workflows.
-  - **The Starter Kit**: The "copy-first" files intended for use in new repositories.
-  - **The Case Studies**: Real-world evidence of the workflow in action.
+  - **The Hub / Playbook**: The definitive place for learning the GitHub-native Jules workflow.
+  - **Reusable Starter Files**: The "copy-first" files within this repo, while linking to the future **jules-workflow-template** as the dedicated starting point.
+  - **The Case Studies**: Real-world evidence like **Case Study A**, showing the workflow in action.
 - Ensure the separation is visually distinct and placed early in the README to guide different types of users.
 
 ## Non-goals
@@ -19,6 +19,7 @@ The current top-level `README.md` is packed with information, making it difficul
 ## Acceptance Criteria
 - [ ] Both English and Korean READMEs are updated with the new section.
 - [ ] The distinction between the three roles is clear and concise.
+- [ ] This repo is clearly framed as the Hub, not the dedicated template repo.
 - [ ] The new section is placed before "Choose Your Track".
 
 ## Validation

--- a/examples/issues/readme-role-separation.md
+++ b/examples/issues/readme-role-separation.md
@@ -1,0 +1,29 @@
+# [Jules Task] Improve README role separation
+
+## Problem
+The current top-level `README.md` is packed with information, making it difficult for first-time visitors to distinguish between the various roles this repository plays: as a Playbook (Hub), a Starter Kit (Template), and a collection of Case Studies.
+
+## Scope
+- Update `README.md` and `README.ko.md` to include a clear "One Repository, Three Roles" section.
+- This section should briefly define:
+  - **The Hub / Playbook**: The central place for learning GitHub-native AI workflows.
+  - **The Starter Kit**: The "copy-first" files intended for use in new repositories.
+  - **The Case Studies**: Real-world evidence of the workflow in action.
+- Ensure the separation is visually distinct and placed early in the README to guide different types of users.
+
+## Non-goals
+- Do not remove existing technical guides or tracks.
+- Do not change the repository structure.
+- Do not use promotional language.
+
+## Acceptance Criteria
+- [ ] Both English and Korean READMEs are updated with the new section.
+- [ ] The distinction between the three roles is clear and concise.
+- [ ] The new section is placed before "Choose Your Track".
+
+## Validation
+- Review the README changes for clarity and tone.
+- Run Markdown hygiene checks.
+
+## Workflow Level
+- Level 1 - Human-led Jules workflow


### PR DESCRIPTION
### Summary
This PR improves the top-level README's role separation, making it easier for users to distinguish between the Hub/Playbook, Starter Kit, and Case Studies. It also adds a new example task that documents this specific improvement.

### Changes
- **README.md & README.ko.md**: Added a "One Repository, Three Roles" (한 개의 저장소, 세 가지 역할) section before the "Choose Your Track" section.
- **examples/issues/readme-role-separation.md**: New file describing the task of improving README role separation.
- **examples/issues/README.md**: Added a link to the new example task.

### Validation
- Ran the Markdown hygiene script from `.github/workflows/docs-and-templates.yml` on all modified files.
- Verified that all internal links in the new sections are correct.
- Requested and received a positive code review (#Correct#).

### Role Separation Details
1. **The Hub / Playbook**: Learning the GitHub-native Jules workflow.
2. **The Starter Kit**: "Copy-first" files for new repositories.
3. **The Case Studies**: Real-world evidence of the workflow.

Fixes #231

---
*PR created automatically by Jules for task [16770524822968427381](https://jules.google.com/task/16770524822968427381) started by @hkimw*