### PR TITLE
Draft: Fleet Mode smoke test issue (FLEET-SMOKE-001)

### DIFF
--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -20,6 +20,7 @@ Jules performs best when the problem and scope are clearly defined. A well-scope
 - [Lightweight CI Task](./lightweight-ci-task.md): Adding minimal docs and template validation.
 - [Case Study B Task](./case-study-b-task.md): Initializing an English-only sample project.
 - [README Role Separation Task](./readme-role-separation.md): Improving top-level role separation for the Hub, Template, and Case Studies.
+- [Fleet Smoke Test Task](./fleet-smoke-001.md): A small documentation task used for verifying Fleet Mode state accounting.
 
 ## How to Use These Examples
 

--- a/examples/issues/fleet-smoke-001.md
+++ b/examples/issues/fleet-smoke-001.md
@@ -1,0 +1,32 @@
+# [Jules Task] Fleet smoke: add tiny docs queue note
+
+## Problem
+
+As we scale Jules usage and explore "Fleet Mode" (running multiple Jules tasks), we need to remind maintainers to keep initial queue tests small and focused to verify state accounting before scaling to large batches.
+
+## Scope
+
+- Add or refine a tiny documentation note in `docs/operations/one-jules-task-at-a-time.md`.
+- The note should advise keeping Fleet queue tests small (e.g., 1-2 tasks) before scaling to ensure state accounting and labeling flows are working as expected.
+- Ensure the note fits naturally within the "Why One Task at a Time?" or "When Are Concurrent Tasks Acceptable?" sections.
+
+## Non-goals
+
+- Do not change the fundamental "One Jules Task at a Time" rule.
+- Do not add complex Fleet Mode configuration details.
+- Do not modify any other files.
+
+## Acceptance Criteria
+
+- [ ] `docs/operations/one-jules-task-at-a-time.md` contains a note about small Fleet queue tests.
+- [ ] The note is clear and concise.
+- [ ] Markdown hygiene passes.
+
+## Validation
+
+- Review the changes in `docs/operations/one-jules-task-at-a-time.md`.
+- Confirm the note is present and accurately reflects the goal of small-scale testing.
+
+## Workflow Level
+
+- Level 1 - Human-led Jules workflow


### PR DESCRIPTION
This PR adds a new draft issue for a Fleet Mode smoke test. The task involves adding a tiny documentation note to `docs/operations/one-jules-task-at-a-time.md` advising maintainers to keep initial Fleet queue tests small. This is a low-risk, docs-only task intended to verify Jules's labeling and state accounting flows.

Changes:
- `examples/issues/fleet-smoke-001.md`: New task definition.
- `examples/issues/README.md`: Link to the new task.

Fixes #235

---
*PR created automatically by Jules for task [16687368057115350244](https://jules.google.com/task/16687368057115350244) started by @hkimw*