### PR TITLE
Create issue draft for Fleet retest 1: README navigation wording check

### DIFF
--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -20,6 +20,7 @@ Jules performs best when the problem and scope are clearly defined. A well-scope
 - [Lightweight CI Task](./lightweight-ci-task.md): Adding minimal docs and template validation.
 - [Case Study B Task](./case-study-b-task.md): Initializing an English-only sample project.
 - [README Role Separation Task](./readme-role-separation.md): Improving top-level role separation for the Hub, Template, and Case Studies.
+- [Fleet Retest README Check](./fleet-retest-003-1-readme-check.md): A small wording check for the README navigation.
 
 ## How to Use These Examples
 

--- a/examples/issues/fleet-retest-003-1-readme-check.md
+++ b/examples/issues/fleet-retest-003-1-readme-check.md
@@ -1,0 +1,28 @@
+# [Jules Task] Fleet retest 1: README navigation wording check
+
+## Problem
+Following recent "One Repository, Three Roles" changes, we need to ensure the top-level README first-screen navigation (the links at the top and the "One Repository, Three Roles" section) is still clear and intuitive for new users.
+
+## Scope
+- Inspect `README.md` (English).
+- Suggest a tiny wording improvement if the navigation links or role definitions could be clearer.
+- If no changes are needed, state that clearly in the PR description.
+
+## Non-goals
+- Do not change workflows.
+- Do not change repository configuration.
+- Do not auto-merge.
+- Do not present Jules as a human contributor.
+- Do not edit more than README.md unless clearly necessary.
+
+## Acceptance Criteria
+- [ ] README.md inspected by Jules.
+- [ ] Wording improvement suggested or current wording confirmed as optimal.
+- [ ] `jules` label is applied to this task.
+
+## Validation
+- Confirm the `jules` label is applied.
+- Review the proposed wording changes for clarity.
+
+## Workflow Level
+- Level 1 - Human-led Jules workflow


### PR DESCRIPTION
I have created a new issue draft file `examples/issues/fleet-retest-003-1-readme-check.md` which asks Jules to inspect the `README.md` navigation wording for clarity. This is task 1 of the Fleet live retest. I also updated `examples/issues/README.md` to link to this new task. All changes were verified for Markdown hygiene.

Fixes #237

---
*PR created automatically by Jules for task [14288661242613768738](https://jules.google.com/task/14288661242613768738) started by @hkimw*