### PR TITLE
Fleet wave 10-2: showcase copy-first wording check

### DIFF
--- a/examples/issues/showcase-wording-check.md
+++ b/examples/issues/showcase-wording-check.md
@@ -1,0 +1,34 @@
+# [Jules Task] Fleet wave 10-2: showcase copy-first wording check
+
+## Problem
+The `docs/showcase.md` file describes the "copy-first" reusable starter files. We must ensure it maintains the correct role separation: this repository is the **Hub and Playbook**, while providing files that can be copied to other repositories (or will eventually power the dedicated template repository). It should not be confused for the template repository itself.
+
+## Goal
+Inspect `docs/showcase.md` and make a tiny wording cleanup only if needed to ensure it doesn't sound like *this* repository is the dedicated template.
+
+## Scope
+- Inspect `docs/showcase.md`.
+- Perform tiny wording cleanups if the current phrasing is ambiguous regarding its role as the Hub vs. a template.
+
+## Non-goals
+- Do not change workflows.
+- Do not change repository configuration.
+- Do not auto-merge.
+- Do not present Jules as a human contributor.
+- Do not make broad rewrites.
+- Do not modify unrelated files.
+
+## Acceptance Criteria
+- [ ] `docs/showcase.md` clearly describes the files as reusable components of the starter kit.
+- [ ] The wording avoids claiming this repository is the template repository.
+- [ ] Changes are minimal and maintain the existing tone.
+
+## Validation
+- Review the wording changes for clarity.
+- Run Markdown hygiene checks.
+
+## Workflow Level
+- Level 1 - Human-led Jules workflow
+
+## Labels
+- `jules`


### PR DESCRIPTION
Created a draft GitHub Issue in examples/issues/showcase-wording-check.md to ask Jules to inspect docs/showcase.md for role-clarity. This task ensures the repository is correctly framed as the Hub and Playbook and not confused with the dedicated template repository.

Fixes #241

---
*PR created automatically by Jules for task [8704223714290365366](https://jules.google.com/task/8704223714290365366) started by @hkimw*