### PR TITLE
Create draft issue for prompts directory index check

### DIFF
--- a/examples/issues/prompts-index-task.md
+++ b/examples/issues/prompts-index-task.md
@@ -1,0 +1,34 @@
+# [Jules Task] Fleet wave 10-8: prompts directory index check
+
+## Goal
+Check whether the `prompts/` directory has enough context for maintainers to use prompts safely and update its index if necessary.
+
+## Problem
+The `prompts/` directory contains reusable prompts for Jules, but it may lack a clear index or README explaining how maintainers should use these prompts safely and effectively.
+
+## Scope
+- Inspect the `prompts/` directory.
+- Update only a prompt README or a small prompt note (e.g., `prompts/README.md`) if one exists.
+- If there is no obvious file, report no change rather than creating broad new content.
+
+## Non-goals
+- Do not change workflows.
+- Do not change repository configuration.
+- Do not auto-merge.
+- Do not present Jules as a human contributor.
+- Do not make broad rewrites.
+- Do not modify unrelated files.
+
+## Acceptance Criteria
+- [ ] The `prompts/` directory has been inspected.
+- [ ] A `README.md` or similar index file in `prompts/` is updated or verified as sufficient.
+- [ ] No broad new content is created if no obvious file exists.
+- [ ] Markdown hygiene passes.
+
+## Validation
+- Confirm that any changes to `prompts/` are minimal and focused on documentation/indexing.
+- Confirm that Jules reported no change if no suitable index file was found.
+
+## Metadata
+- Labels: `jules`
+- Track: Review-Driven


### PR DESCRIPTION
Created a new draft issue file `examples/issues/prompts-index-task.md` for the Jules task "Fleet wave 10-8: prompts directory index check". This fulfills the requirement to create exactly one GitHub Issue (as a reviewable draft in this environment) with the 'jules' label and documentation focus.

Verification:
- File content verified with `read_file`.
- Markdown hygiene verified with a custom Python script.
- Code review performed and passed.

Fixes #247

---
*PR created automatically by Jules for task [6744720194152507200](https://jules.google.com/task/6744720194152507200) started by @hkimw*