### PR TITLE
docs: add labels and triage alignment example task

### DIFF
--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -20,6 +20,7 @@ Jules performs best when the problem and scope are clearly defined. A well-scope
 - [Lightweight CI Task](./lightweight-ci-task.md): Adding minimal docs and template validation.
 - [Case Study B Task](./case-study-b-task.md): Initializing an English-only sample project.
 - [README Role Separation Task](./readme-role-separation.md): Improving top-level role separation for the Hub, Template, and Case Studies.
+- [Labels and Triage Alignment](./labels-and-triage-alignment.md): Aligning triage documentation with the Review-Driven track.
 
 ## How to Use These Examples
 

--- a/examples/issues/labels-and-triage-alignment.md
+++ b/examples/issues/labels-and-triage-alignment.md
@@ -1,0 +1,39 @@
+# [Jules Task] Align Labels and Triage with Review-Driven Track terminology
+
+## Problem
+
+The documentation in `docs/operations/labels-and-triage.md` describes the standard triage flow but does not explicitly name it the "Review-Driven" track, which is the primary terminology used in `docs/tracks/review-driven.md` and `AGENTS.md`. Consistency in terminology helps users navigate the workflow tracks.
+
+## Scope
+
+- Inspect `docs/operations/labels-and-triage.md`.
+- Update the wording in the "Suggested Triage Flow" section or introduction to explicitly reference the "Review-Driven" track as the default workflow.
+- Ensure the description of the flow remains consistent with the steps outlined in `docs/tracks/review-driven.md`.
+- Perform a tiny wording cleanup only if needed to improve clarity and alignment.
+
+## Non-goals
+
+- Do not change the actual workflows or labels.
+- Do not change repository configuration.
+- Do not auto-merge.
+- Do not present Jules as a human contributor.
+- Do not make broad rewrites.
+- Do not modify unrelated files.
+
+## Acceptance Criteria
+
+- [ ] `docs/operations/labels-and-triage.md` explicitly mentions the "Review-Driven" track.
+- [ ] The terminology aligns with `docs/tracks/review-driven.md`.
+- [ ] Markdown hygiene passes (newline at end, no tabs, 0 or 2 trailing spaces).
+
+## Validation
+
+- Read `docs/operations/labels-and-triage.md` to confirm the update.
+- Verify consistency with `docs/tracks/review-driven.md`.
+
+## Labels
+`jules`, `documentation`, `workflow`
+
+## Workflow Level
+
+- Level 1 - Human-led Jules workflow


### PR DESCRIPTION
This PR adds a new example issue task to the `examples/issues/` directory.

The task, `labels-and-triage-alignment.md`, asks Jules to inspect `docs/operations/labels-and-triage.md` and ensure it explicitly uses the "Review-Driven" track terminology, aligning it with `docs/tracks/review-driven.md` and `AGENTS.md`.

Changes:
- Added `examples/issues/labels-and-triage-alignment.md`
- Updated `examples/issues/README.md` to include a link to the new task.

This fulfills the requirement of creating a docs-only issue task for the Fleet wave 10-10.

Fixes #249

---
*PR created automatically by Jules for task [7717221572322343850](https://jules.google.com/task/7717221572322343850) started by @hkimw*