### PR TITLE
Create PR Review Wording Check Task (Fleet Wave 10-7)

### DIFF
--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -20,6 +20,7 @@ Jules performs best when the problem and scope are clearly defined. A well-scope
 - [Lightweight CI Task](./lightweight-ci-task.md): Adding minimal docs and template validation.
 - [Case Study B Task](./case-study-b-task.md): Initializing an English-only sample project.
 - [README Role Separation Task](./readme-role-separation.md): Improving top-level role separation for the Hub, Template, and Case Studies.
+- [PR Review Wording Check](./pr-review-wording-task.md): Ensuring AI framing in example PR reviews.
 
 ## How to Use These Examples
 

--- a/examples/issues/pr-review-wording-task.md
+++ b/examples/issues/pr-review-wording-task.md
@@ -1,0 +1,35 @@
+# [Jules Task] PR Review Examples Wording Check
+
+## Problem
+
+The examples in `examples/pr-reviews/` demonstrate how human maintainers provide feedback to Jules. We need to ensure that the wording in these examples consistently frames Jules as an AI coding agent and never implies human identity or authorship.
+
+## Scope
+
+- Inspect all files in `examples/pr-reviews/`.
+- Perform tiny wording cleanups ONLY if the AI framing is weak or incorrect.
+- Ensure the language reinforces that Jules is an AI agent being steered by a human.
+
+## Non-goals
+
+- Do not change workflows.
+- Do not change repository configuration.
+- Do not auto-merge.
+- Do not present Jules as a human contributor.
+- Do not make broad rewrites.
+- Do not modify unrelated files.
+
+## Acceptance Criteria
+
+- [ ] All files in `examples/pr-reviews/` correctly frame Jules as an AI coding agent.
+- [ ] No wording suggests human identity for Jules.
+- [ ] Markdown hygiene is maintained.
+
+## Validation
+
+- Review the changes in `examples/pr-reviews/`.
+- Confirm that the AI agent framing is strictly followed.
+
+## Workflow Level
+
+- Level 1 - Human-led Jules workflow


### PR DESCRIPTION
Created a new Jules task definition to check the wording in the `examples/pr-reviews/` directory. This task ensures that Jules is consistently framed as an AI coding agent and not a human contributor in all review examples. The new task is registered in the `examples/issues/README.md` index. This is a docs-only change.

Fixes #246

---
*PR created automatically by Jules for task [9403001159861960735](https://jules.google.com/task/9403001159861960735) started by @hkimw*