### PR TITLE
Create draft issue for Korean README polish (Fleet wave 10-9)

### DIFF
--- a/examples/issues/fleet-wave-10-9-korean-readme-polish.md
+++ b/examples/issues/fleet-wave-10-9-korean-readme-polish.md
@@ -1,0 +1,31 @@
+# [Jules Task] Fleet wave 10-9: Korean README role wording polish
+
+**Labels**: `jules`, `docs-only`
+
+## Problem
+The "One Repository, Three Roles" section was recently added to both `README.md` and `README.ko.md`. We need to ensure that the Korean translation in `README.ko.md` feels natural to a native speaker and accurately mirrors the intent of the English version without being a stiff word-for-word translation.
+
+## Scope
+- Inspect `README.ko.md`, specifically the "한 개의 저장소, 세 가지 역할" (One Repository, Three Roles) section.
+- Compare it with the English `README.md` counterpart.
+- Make tiny wording cleanups to ensure natural phrasing in Korean if needed.
+
+## Non-goals
+- Do not change workflows.
+- Do not change repository configuration.
+- Do not auto-merge.
+- Do not present Jules as a human contributor.
+- Do not make broad rewrites.
+- Do not modify unrelated files.
+
+## Acceptance Criteria
+- [ ] `README.ko.md` wording is checked and polished for naturalness if needed.
+- [ ] The "Three Roles" distinction remains clear and aligned with the English version.
+- [ ] No structural changes are made to the document.
+
+## Validation
+- Review the diff for linguistic naturalness.
+- Run markdown hygiene checks.
+
+## Workflow Level
+- Level 1 - Human-led Jules workflow


### PR DESCRIPTION
This submission creates a new draft issue for a documentation-only task. The task involves inspecting `README.ko.md` to ensure the recently added "One Repository, Three Roles" section (한 개의 저장소, 세 가지 역할) reads naturally in Korean and aligns with the English `README.md`.

Changes:
- Created `examples/issues/fleet-wave-10-9-korean-readme-polish.md` following the `jules_task.yml` template.
- Verified markdown hygiene.
- No changes to workflows or project configuration.

Fixes #248

---
*PR created automatically by Jules for task [11119761428516524801](https://jules.google.com/task/11119761428516524801) started by @hkimw*