### PR TITLE
Add example issue for Fleet queue test size note

### DIFF
--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -20,6 +20,7 @@ Jules performs best when the problem and scope are clearly defined. A well-scope
 - [Lightweight CI Task](./lightweight-ci-task.md): Adding minimal docs and template validation.
 - [Case Study B Task](./case-study-b-task.md): Initializing an English-only sample project.
 - [README Role Separation Task](./readme-role-separation.md): Improving top-level role separation for the Hub, Template, and Case Studies.
+- [Fleet Queue Test Size Task](./fleet-queue-test-size-task.md): Adding a note about starting Fleet queue tests small before scaling.
 
 ## How to Use These Examples
 

--- a/examples/issues/fleet-queue-test-size-task.md
+++ b/examples/issues/fleet-queue-test-size-task.md
@@ -1,0 +1,24 @@
+# [Jules Task] Fleet queue test size operations guide note
+
+## Problem
+Fleet queue tests should be conducted incrementally to ensure stability and reliable state accounting. We need to document the recommendation to start small before scaling to larger batches.
+
+## Scope
+- Update `docs/operations/one-jules-task-at-a-time.md` to include a short note about Fleet queue testing strategy.
+- The note should recommend starting with 1 task, then 3 tasks, before moving to larger batches.
+
+## Non-goals
+- Do not change workflows or repository configuration.
+- Do not perform unrelated documentation refactors.
+
+## Acceptance Criteria
+- [ ] `docs/operations/one-jules-task-at-a-time.md` contains the new note about Fleet queue scaling.
+- [ ] The note is concise and clear.
+- [ ] Markdown hygiene passes (no tabs, single newline at EOF, 0 or 2 trailing spaces).
+
+## Validation
+- Verify the content of `docs/operations/one-jules-task-at-a-time.md`.
+- Ensure the documentation remains scannable and accurate.
+
+## Workflow Level
+- Level 1 - Human-led Jules workflow


### PR DESCRIPTION
I have drafted a new example issue in `examples/issues/fleet-queue-test-size-task.md` that instructs Jules to add a short note to `docs/operations/one-jules-task-at-a-time.md` regarding Fleet queue testing strategies (recommending an incremental scale of 1, then 3, then larger batches). I also updated the `examples/issues/README.md` index to include this new draft. Both files have been verified for Markdown hygiene. Due to lack of GitHub authentication in the sandbox, this draft serves as the reviewable task for the maintainer to open as a live issue.

Fixes #239

---
*PR created automatically by Jules for task [12259686424036981371](https://jules.google.com/task/12259686424036981371) started by @hkimw*