### PR TITLE
Add draft issue for Case Study A wording check (Fleet Wave 10-3)

### DIFF
--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -18,6 +18,7 @@ Jules performs best when the problem and scope are clearly defined. A well-scope
 - [Template README Task](./template-readme-task.md): Drafting a copy-first README for a new repository.
 - [Minimal PR Template Task](./pr-template-task.md): Drafting a reusable PR template.
 - [Lightweight CI Task](./lightweight-ci-task.md): Adding minimal docs and template validation.
+- [Case Study A Wording Check](./case-study-a-wording-check.md): Verifying the Case Study A framing.
 - [Case Study B Task](./case-study-b-task.md): Initializing an English-only sample project.
 - [README Role Separation Task](./readme-role-separation.md): Improving top-level role separation for the Hub, Template, and Case Studies.
 

--- a/examples/issues/case-study-a-wording-check.md
+++ b/examples/issues/case-study-a-wording-check.md
@@ -1,0 +1,34 @@
+# [Jules Task] Case Study A wording check
+
+## Problem
+As the repository evolves from a prototype to a structured playbook, we need to ensure that our primary case study is framed correctly. We need to verify if `docs/case-studies/digital-logic-circuit.md` still correctly frames the Digital Logic Circuit project as "Case Study A," and not as a generic template.
+
+## Scope
+- Inspect `docs/case-studies/digital-logic-circuit.md`.
+- Verify that it identifies the project as "Case Study A".
+- Make tiny wording cleanups only if needed to reinforce this framing.
+- Ensure Jules is described as an AI coding agent.
+
+## Target area
+- `docs/case-studies/digital-logic-circuit.md`
+
+## Non-goals
+- Do not change workflows.
+- Do not change repository configuration.
+- Do not auto-merge.
+- Do not present Jules as a human contributor.
+- Do not make broad rewrites.
+- Do not modify unrelated files.
+
+## Acceptance Criteria
+- [ ] The file `docs/case-studies/digital-logic-circuit.md` is reviewed.
+- [ ] Any "generic template" language is replaced with "Case Study A" framing where appropriate.
+- [ ] Jules is correctly framed as an AI coding agent.
+- [ ] No unrelated files are modified.
+
+## Validation
+- Perform a manual read-through of the file after any changes.
+- Confirm the framing matches the Hub role separation (Hub, Template, Case Studies).
+
+## Workflow Level
+Level 1 - Human-led Jules workflow (Docs only)


### PR DESCRIPTION
This PR adds a new draft issue definition to `examples/issues/` as part of Fleet Wave 10-3.

### Changes:
- Created `examples/issues/case-study-a-wording-check.md`: A scoped task for Jules to verify that `docs/case-studies/digital-logic-circuit.md` is correctly framed as "Case Study A" and adheres to AI framing guidelines.
- Updated `examples/issues/README.md`: Added the new task to the index of example issues.

### Note on Execution:
As the environment does not have authenticated GitHub CLI access, I have fulfilled the "Create Issue" request by providing the issue content as a reviewable Markdown file within the repository's established `examples/issues/` structure, ensuring the task is documented and ready for manual or automated creation by a maintainer.

Fixes #242

---
*PR created automatically by Jules for task [5263429149181263006](https://jules.google.com/task/5263429149181263006) started by @hkimw*