### PR TITLE
Add draft issue for applied rollout guide gap check

### DIFF
--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -20,6 +20,7 @@ Jules performs best when the problem and scope are clearly defined. A well-scope
 - [Lightweight CI Task](./lightweight-ci-task.md): Adding minimal docs and template validation.
 - [Case Study B Task](./case-study-b-task.md): Initializing an English-only sample project.
 - [README Role Separation Task](./readme-role-separation.md): Improving top-level role separation for the Hub, Template, and Case Studies.
+- [Applied Rollout Guide Task](./rollout-guide-task.md): Auditing rollout guidance for existing repositories.
 
 ## How to Use These Examples
 

--- a/examples/issues/rollout-guide-task.md
+++ b/examples/issues/rollout-guide-task.md
@@ -1,0 +1,44 @@
+# [Jules Task] Applied rollout guide gap check
+
+**Labels**: `jules`, `documentation`, `operations`
+
+## Problem
+
+The repository contains operations guides for labels, triage, and sequencing, but it may lack a clear, step-by-step path for applying the Jules workflow to an existing, non-starter-kit repository.
+
+## Goal
+
+Ensure that `docs/operations/` provides a clear starting point for maintainers who want to adopt this workflow in their own projects.
+
+## Scope
+
+- Inspect the contents of `docs/operations/`.
+- If a guide for applying Jules to an existing repo is missing, propose a minimal `apply-to-existing-repo.md` outline.
+- If a relevant guide exists but isn't easily discoverable, add a tiny link or note to the appropriate operations document.
+- Ensure the guidance remains practical, GitHub-native, and frames Jules as an AI coding agent.
+
+## Non-goals
+
+- Do not change workflows.
+- Do not change repository configuration.
+- Do not auto-merge.
+- Do not present Jules as a human contributor.
+- Do not make broad rewrites.
+- Do not modify unrelated files.
+
+## Acceptance Criteria
+
+- [ ] `docs/operations/` is audited for rollout guidance.
+- [ ] A minimal guide is proposed or a discoverability link is added.
+- [ ] Markdown hygiene passes.
+- [ ] The change is docs-only and low-risk.
+
+## Validation
+
+- Confirm the existence or update of the rollout guide.
+- Verify that links are relative and functional.
+- Confirm Jules is framed as an AI coding agent.
+
+## Workflow Level
+
+- Level 1 - Human-led Jules workflow


### PR DESCRIPTION
This PR adds a new example issue draft to `examples/issues/` that tasks Jules with auditing the `docs/operations/` directory for a clear "apply-to-existing-repo" rollout guide.

This fulfills the requirement of [Jules Task #FLEET-WAVE-010-4]. In unauthenticated environments, creating a draft file in `examples/issues/` is the standard way to provide reviewable content for "create issue" tasks.

Key features:
- Scoped Jules task following the project template.
- Includes `jules`, `documentation`, and `operations` labels.
- Linked in the `examples/issues/README.md` index.
- Validated with markdown hygiene checks.

Fixes #243

---
*PR created automatically by Jules for task [13070851636342000070](https://jules.google.com/task/13070851636342000070) started by @hkimw*