### PR TITLE
Fleet wave 10-1: quickstart role separation check issue draft

### DIFF
--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -20,6 +20,7 @@ Jules performs best when the problem and scope are clearly defined. A well-scope
 - [Lightweight CI Task](./lightweight-ci-task.md): Adding minimal docs and template validation.
 - [Case Study B Task](./case-study-b-task.md): Initializing an English-only sample project.
 - [README Role Separation Task](./readme-role-separation.md): Improving top-level role separation for the Hub, Template, and Case Studies.
+- [Quickstart Role Separation Task](./quickstart-role-separation-task.md): Checking role separation in the Quickstart guide.
 
 ## How to Use These Examples
 

--- a/examples/issues/quickstart-role-separation-task.md
+++ b/examples/issues/quickstart-role-separation-task.md
@@ -1,0 +1,26 @@
+# [Jules Task] Quickstart role separation check
+
+## Problem
+We need to ensure `docs/quickstart.md` clearly separates the Hub/Playbook repository from the future template repository to avoid user confusion.
+
+## Scope
+- Inspect `docs/quickstart.md` (specifically the introduction and Step 1).
+- Make a tiny wording cleanup **only if** the copy-first path is unclear or if the distinction between this Hub and the dedicated template repo needs reinforcement.
+- Ensure the tone matches the "One Repository, Three Roles" framing in the main README.
+
+## Non-goals
+- Do not change workflows or repository configuration.
+- Do not make broad rewrites.
+- Do not modify unrelated files.
+
+## Acceptance Criteria
+- [ ] `docs/quickstart.md` wording is checked for role separation.
+- [ ] Any necessary cleanups are minimal and docs-only.
+- [ ] The "copy-first" path remains clear for users.
+
+## Validation
+- Confirm the wording aligns with the repository's role as a Hub.
+- Run Markdown hygiene checks.
+
+## Workflow Level
+- Level 1 - Human-led Jules workflow


### PR DESCRIPTION
This PR creates a new draft issue in `examples/issues/quickstart-role-separation-task.md` as requested for Fleet wave 10-1. The task asks Jules to inspect `docs/quickstart.md` and clarify the role separation between the Hub/Playbook and the future template repository.

The change includes:
- A new example issue file: `examples/issues/quickstart-role-separation-task.md`
- An update to the example index: `examples/issues/README.md`

All files have been validated for Markdown hygiene (final newline, no tabs, correct trailing spaces).

Fixes #240

---
*PR created automatically by Jules for task [6522905585881671896](https://jules.google.com/task/6522905585881671896) started by @hkimw*