### PR TITLE
Add Jules audit task for first-contributions.md clarity

### DIFF
--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -20,6 +20,7 @@ Jules performs best when the problem and scope are clearly defined. A well-scope
 - [Lightweight CI Task](./lightweight-ci-task.md): Adding minimal docs and template validation.
 - [Case Study B Task](./case-study-b-task.md): Initializing an English-only sample project.
 - [README Role Separation Task](./readme-role-separation.md): Improving top-level role separation for the Hub, Template, and Case Studies.
+- [First Contributions Audit Task](./first-contributions-audit-task.md): Auditing clarity of the first contributions guide for new contributors.
 
 ## How to Use These Examples
 

--- a/examples/issues/first-contributions-audit-task.md
+++ b/examples/issues/first-contributions-audit-task.md
@@ -1,0 +1,28 @@
+# [Jules Task] Audit first-contributions.md for workflow clarity
+
+## Problem
+New contributors must understand the fundamental GitHub-native workflow: Issue → PR → CI → Human review. We need to ensure that `docs/contributing/first-contributions.md` explains this clearly and emphasizes human review as the final gate.
+
+## Scope
+- Inspect `docs/contributing/first-contributions.md`.
+- Audit the text for clarity regarding the "Issue → PR → CI → Human review" workflow.
+- Make tiny wording cleanups **only if needed** to improve readability for new contributors.
+- Ensure Jules is framed as an AI coding agent and not a human.
+
+## Non-goals
+- Do not change the underlying workflows.
+- Do not add or change repository configurations.
+- Do not broad rewrites; keep changes minimal.
+- Do not modify unrelated files.
+
+## Acceptance Criteria
+- [ ] `docs/contributing/first-contributions.md` is audited for clarity.
+- [ ] If cleanups were made, they are minor and improve workflow transparency.
+- [ ] Markdown hygiene passes (no tabs, single trailing newline).
+
+## Validation
+- Review the diff to confirm only minor wording improvements were made.
+- Verify that the human review requirement remains prominent.
+
+## Workflow Level
+- Level 1 - Human-led Jules workflow


### PR DESCRIPTION
This PR adds a new Jules-ready issue draft to `examples/issues/` and updates the directory index. This fulfills the requirement for Fleet wave 10-6 by providing the content for a documentation audit task focused on workflow clarity in `docs/contributing/first-contributions.md`.

Changes:
- Created `examples/issues/first-contributions-audit-task.md` with a scoped audit task.
- Updated `examples/issues/README.md` to include the new task.

The draft emphasizes:
- Inspecting the "Issue -> PR -> CI -> Human review" workflow explanation.
- Minimal wording cleanups only if needed.
- Framing Jules as an AI coding agent.
- Mandatory human review.

Fixes #245

---
*PR created automatically by Jules for task [2556191864061165875](https://jules.google.com/task/2556191864061165875) started by @hkimw*