### PR TITLE
Add Fleet continuous smoke test example issue

### DIFF
--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -20,6 +20,7 @@ Jules performs best when the problem and scope are clearly defined. A well-scope
 - [Lightweight CI Task](./lightweight-ci-task.md): Adding minimal docs and template validation.
 - [Case Study B Task](./case-study-b-task.md): Initializing an English-only sample project.
 - [README Role Separation Task](./readme-role-separation.md): Improving top-level role separation for the Hub, Template, and Case Studies.
+- [Fleet Continuous Smoke Task](./fleet-cont-smoke-005-1.md): A small wording check task for validating Fleet pop-and-dispatch behavior.
 
 ## How to Use These Examples
 

--- a/examples/issues/fleet-cont-smoke-005-1.md
+++ b/examples/issues/fleet-cont-smoke-005-1.md
@@ -1,0 +1,42 @@
+# [Jules Task] Fleet continuous smoke 1: docs index wording check
+
+## Problem
+
+This is a controlled live smoke for autorun-jules PR #18. The runner should be started with JULES_MAX_CONCURRENT=3, so only three tasks should dispatch at first and the remaining two should wait until a slot opens.
+
+## Scope
+
+Inspect `docs/operations/labels-and-triage.md` and check the description of the `jules` label.
+
+The current text describes it as purely "informational," but in Fleet Mode v1, the `jules` label can also act as an automated dispatch trigger for the Continuous Scheduler.
+
+**Proposed Change:**
+Update the description of the `jules` label in `docs/operations/labels-and-triage.md` to acknowledge its role in automated dispatch if applicable.
+
+Target file:
+`docs/operations/labels-and-triage.md`
+
+## Non-goals
+
+- Do not change workflows.
+- Do not change repository configuration.
+- Do not auto-merge.
+- Do not present Jules as a human contributor.
+- Do not make broad rewrites.
+- Do not modify unrelated files.
+
+## Acceptance Criteria
+
+- [ ] Exactly one GitHub Issue is created for this task.
+- [ ] The issue is docs-only and low-risk.
+- [ ] The `jules` label is applied.
+- [ ] No PR is merged automatically.
+
+## Validation
+
+- Confirm the issue URL and `jules` label.
+
+## Workflow Level
+
+- Level 1 - Human-led Jules workflow
+- Fleet Mode v1 pop-and-dispatch validation


### PR DESCRIPTION
This PR adds a new example issue draft `examples/issues/fleet-cont-smoke-005-1.md` and updates the index in `examples/issues/README.md`. The new example is designed as a smoke test for the Fleet Continuous Scheduler, targeting a specific documentation update in `docs/operations/labels-and-triage.md`. This follows the repository's pattern of providing "copy-first" issue examples for AI agent tasks.

Fixes #263

---
*PR created automatically by Jules for task [15571344565870535569](https://jules.google.com/task/15571344565870535569) started by @hkimw*