### PR TITLE
Add Fleet smoke test task draft

### DIFF
--- a/examples/issues/README.md
+++ b/examples/issues/README.md
@@ -20,6 +20,7 @@ Jules performs best when the problem and scope are clearly defined. A well-scope
 - [Lightweight CI Task](./lightweight-ci-task.md): Adding minimal docs and template validation.
 - [Case Study B Task](./case-study-b-task.md): Initializing an English-only sample project.
 - [README Role Separation Task](./readme-role-separation.md): Improving top-level role separation for the Hub, Template, and Case Studies.
+- [Fleet README Wording Check](./fleet-readme-wording-check.md): A smoke test task for verifying Fleet Continuous Scheduler dispatch.
 
 ## How to Use These Examples
 

--- a/examples/issues/fleet-readme-wording-check.md
+++ b/examples/issues/fleet-readme-wording-check.md
@@ -1,0 +1,29 @@
+# [Jules Task] Fleet continuous smoke 2: README concise wording check
+
+## Problem
+This is a controlled live smoke test for the Fleet Continuous Scheduler (Task ID: #FLEET-CONT-SMOKE-005-2). The goal is to verify that the scheduler correctly pops and dispatches tasks while also performing a minor, low-risk documentation check.
+
+## Scope
+- Inspect `README.md` for any tiny wording cleanups, typos, or concise wording improvements.
+- If a minor improvement is found, apply it in a focused PR.
+- If no changes are necessary, report that the inspection was completed.
+
+## Non-goals
+- Do not change workflows or repository configuration.
+- Do not auto-merge.
+- Do not present Jules as a human contributor.
+- Do not make broad rewrites.
+- Do not modify unrelated files.
+
+## Acceptance Criteria
+- [ ] `README.md` has been inspected for wording consistency.
+- [ ] A focused PR is created with any identified minor wording improvements.
+- [ ] No unrelated files are modified.
+- [ ] The `jules` label is applied to the resulting work.
+
+## Validation
+- Review the PR changes for clarity and tone.
+- Confirm that the changes are limited to documentation only.
+
+## Workflow Level
+- Level 1 - Human-led Jules workflow


### PR DESCRIPTION
Adds a new Jules task draft for Fleet continuous smoke testing (Task ID #FLEET-CONT-SMOKE-005-2) to the `examples/issues/` directory and updates the `examples/issues/README.md` index. This fulfills the task requirement to create reviewable content for verifying scheduler dispatch behavior in an environment where direct GitHub Issue creation is restricted.

Fixes #264

---
*PR created automatically by Jules for task [18446518449793327671](https://jules.google.com/task/18446518449793327671) started by @hkimw*